### PR TITLE
Fix run_web_dev.sh, add CI smoke test, extract test scripts to tools/test/

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -78,11 +78,13 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: shellcheck
-        run: shellcheck -x tools/*.sh
+        run: shellcheck -x tools/*.sh tools/test/*.sh
       - name: run_chat.sh smoke test
         run: sh ./tools/run_chat.sh --help
       - name: run_web.sh smoke test
         run: sh ./tools/run_web.sh --help
+      - name: run_web_dev.sh smoke test
+        run: sh tools/test/run_web_dev.sh
       - name: set_up_systemd.sh dry-run
         run: sh ./tools/set_up_systemd.sh --dry-run
 
@@ -144,12 +146,6 @@ jobs:
           vuln-type: os,library
           severity: CRITICAL,HIGH
       - name: "Verify chat: invalid token raises LoginFailure"
-        run: |
-          output=$(docker run --rm initbot-chat --token 123 2>&1) || true
-          echo "$output"
-          echo "$output" | grep -qF "discord.errors.LoginFailure"
+        run: sh tools/test/docker_chat.sh
       - name: "Verify web: missing SQLite state raises SystemExit"
-        run: |
-          output=$(docker run --rm initbot-web 2>&1) || true
-          echo "$output"
-          echo "$output" | grep -qF "initbot-web requires a SQLite state URI"
+        run: sh tools/test/docker_web.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,10 @@ repos:
     rev: a1bb792acda6fd0724936b4ebbdbc8eceb9c0459  # v6.2.0  # pragma: allowlist secret
     hooks:
       - id: reuse
+        # --no-multiprocessing: reuse uses ProcessPoolExecutor by default,
+        # which requires semaphore creation. This fails in sandboxed
+        # environments (e.g. nono) that block the sem_open syscall.
+        args: [--no-multiprocessing, lint]
   - repo: local
     hooks:
       # Prevent tag-based pre-commit pins slipping in via manual edits or

--- a/tools/run_web_dev.sh
+++ b/tools/run_web_dev.sh
@@ -14,14 +14,24 @@ trap 'rm -rf "${DEV_JSON_DIR}"' EXIT
 python3 - "${DEV_JSON_DIR}" <<'PYEOF'
 import json, sys, time
 now = int(time.time())
-characters = [
-    {"name": "Aldric",       "user": "Stefan", "initiative": 18, "initiative_dice": "d20+2", "last_used": now},
-    {"name": "Mira",         "user": "Anna",   "initiative": 15, "initiative_dice": "d20+1", "last_used": now},
-    {"name": "Brother Thog", "user": "Bob",    "initiative": 15, "initiative_dice": "d20",   "last_used": now},
-    {"name": "Elara",        "user": "Carol",  "initiative":  9, "initiative_dice": "d20-1", "last_used": now},
-    {"name": "Zyx",          "user": "Dave",   "initiative":  3, "initiative_dice": "d20-2", "last_used": now},
-    {"name": "Tara",         "user": "Eve",                                                  "last_used": now},
+players = [
+    {"id": 1, "discord_id": 1001, "name": "Stefan"},
+    {"id": 2, "discord_id": 1002, "name": "Anna"},
+    {"id": 3, "discord_id": 1003, "name": "Bob"},
+    {"id": 4, "discord_id": 1004, "name": "Carol"},
+    {"id": 5, "discord_id": 1005, "name": "Dave"},
+    {"id": 6, "discord_id": 1006, "name": "Eve"},
 ]
+characters = [
+    {"name": "Aldric",       "player_id": 1, "initiative": 18, "initiative_dice": "d20+2", "last_used": now},
+    {"name": "Mira",         "player_id": 2, "initiative": 15, "initiative_dice": "d20+1", "last_used": now},
+    {"name": "Brother Thog", "player_id": 3, "initiative": 15, "initiative_dice": "d20",   "last_used": now},
+    {"name": "Elara",        "player_id": 4, "initiative":  9, "initiative_dice": "d20-1", "last_used": now},
+    {"name": "Zyx",          "player_id": 5, "initiative":  3, "initiative_dice": "d20-2", "last_used": now},
+    {"name": "Tara",         "player_id": 6,                                                "last_used": now},
+]
+with open(f"{sys.argv[1]}/players.json", "w") as f:
+    json.dump({"players": players}, f)
 with open(f"{sys.argv[1]}/characters.json", "w") as f:
     json.dump({"characters": characters}, f)
 PYEOF

--- a/tools/test/docker_chat.sh
+++ b/tools/test/docker_chat.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -ue
+
+output=$(docker run --rm initbot-chat --token 123 2>&1) || true
+echo "$output"
+echo "$output" | grep -qF "discord.errors.LoginFailure"

--- a/tools/test/docker_web.sh
+++ b/tools/test/docker_web.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -ue
+
+output=$(docker run --rm initbot-web 2>&1) || true
+echo "$output"
+echo "$output" | grep -qF "initbot-web requires a SQLite state URI"

--- a/tools/test/run_web_dev.sh
+++ b/tools/test/run_web_dev.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -ue
+
+cd "$(dirname "$(realpath "${0}")")"/../..
+
+tools/run_web_dev.sh &
+WEB_PID=$!
+trap 'kill "$WEB_PID" 2>/dev/null || true; wait "$WEB_PID" 2>/dev/null || true' EXIT
+
+for i in $(seq 1 30); do
+    if curl -s -o /dev/null http://localhost:8080/; then
+        echo "Web server started successfully after ${i}s"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "Web server failed to start within 30 seconds"
+exit 1


### PR DESCRIPTION
## Summary

- Fix `tools/run_web_dev.sh`: add missing player sample data that caused the script to fail on a fresh checkout
- Add `tools/test/run_web_dev.sh`: starts the dev web server, polls until port 8080 responds, then terminates it — runnable by developers locally and wired into CI
- Add `tools/test/docker_chat.sh` and `tools/test/docker_web.sh`: extracted from inline CI steps so they are runnable locally as well as in CI
- Extend `shellcheck` glob to cover `tools/test/*.sh`
- Configure the `reuse` pre-commit hook with `--no-multiprocessing` to avoid `sem_open` failures in sandboxed environments

## Test plan

- [ ] CI passes on this branch
- [ ] `sh tools/test/run_web_dev.sh` starts and cleanly terminates the dev web server locally
- [ ] `sh tools/test/docker_chat.sh` and `sh tools/test/docker_web.sh` work after building the Docker images