### PR TITLE
Fix login token consumed by Discord link-preview bot

### DIFF
--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import logging
 import re
 import time
 from asyncio import sleep
@@ -25,6 +26,28 @@ POLL_INTERVAL = 1.5
 STALE_SECONDS = 24 * 3600
 SESSION_TTL: Final[int] = 8 * 3600
 
+_log = logging.getLogger(__name__)
+
+
+def _require_auth(request: Request) -> Response | None:
+    """Return a 403 Response if the session is missing or expired, else None."""
+    if not request.session.get("authenticated"):
+        return Response(status_code=403)
+    expires_at = request.session.get("expires_at")
+    if expires_at is None or time.time() > expires_at:
+        request.session.clear()
+        return Response(status_code=403)
+    return None
+
+
+def _write_session(
+    request: Request, discord_id: int | None, player_name: str | None
+) -> None:
+    request.session["authenticated"] = True
+    request.session["discord_id"] = discord_id
+    request.session["player_name"] = player_name
+    request.session["expires_at"] = int(time.time()) + SESSION_TTL
+
 
 def make_routes(
     state: State,
@@ -35,25 +58,27 @@ def make_routes(
     tracker_url = f"/{url_path_prefix}/tracker/"
     sse_url = f"/{url_path_prefix}/tracker/sse"
 
-    def _require_auth(request: Request) -> Response | None:
-        """Return a 403 Response if the session is missing or expired, else None."""
-        if not request.session.get("authenticated"):
-            return Response(status_code=403)
-        expires_at = request.session.get("expires_at")
-        if expires_at is None or time.time() > expires_at:
-            request.session.clear()
-            return Response(status_code=403)
-        return None
+    async def login_page(request: Request) -> Response:
+        """GET: validate token without consuming it; render auto-submit login form.
 
-    def _write_session(
-        request: Request, discord_id: int | None, player_name: str | None
-    ) -> None:
-        request.session["authenticated"] = True
-        request.session["discord_id"] = discord_id
-        request.session["player_name"] = player_name
-        request.session["expires_at"] = int(time.time()) + SESSION_TTL
+        Bots and link-preview crawlers (e.g. Discordbot) make GET requests but never
+        submit forms, so the token is preserved for the actual user.
+        """
+        token = request.path_params["token"]
+        _log.info(
+            "login GET: scheme=%s x-forwarded-proto=%s",
+            request.url.scheme,
+            request.headers.get("x-forwarded-proto", "<absent>"),
+        )
+        is_player_token = state.web_login_tokens.find_valid(token) is not None
+        is_admin_token = bool(url_path_prefix) and token == url_path_prefix
+        if not (is_player_token or is_admin_token):
+            _log.warning("login GET: invalid or already-used token")
+            return Response(status_code=403)
+        return templates.TemplateResponse(request, "login.html", {})
 
-    async def login_redirect(request: Request) -> Response:
+    async def login_post(request: Request) -> Response:
+        """POST: consume token, write session, redirect to tracker."""
         token = request.path_params["token"]
         discord_id = state.web_login_tokens.find_valid(token)
         if discord_id is not None:
@@ -62,10 +87,20 @@ def make_routes(
             _write_session(
                 request, discord_id, player.name if player is not None else None
             )
-            return RedirectResponse(tracker_url, status_code=302)
+            _log.info(
+                "login POST: session written discord_id=%s session_keys=%s",
+                discord_id,
+                list(request.session.keys()),
+            )
+            return RedirectResponse(tracker_url, status_code=303)
         if url_path_prefix and token == url_path_prefix:
             _write_session(request, None, None)
-            return RedirectResponse(tracker_url, status_code=302)
+            _log.info(
+                "login POST: admin session written session_keys=%s",
+                list(request.session.keys()),
+            )
+            return RedirectResponse(tracker_url, status_code=303)
+        _log.warning("login POST: invalid or already-used token")
         return Response(status_code=403)
 
     async def tracker_page(request: Request) -> Response:
@@ -142,7 +177,8 @@ def make_routes(
                 Route("/tracker/", tracker_page),
                 Route("/tracker/sse", tracker_sse),
                 Route("/logout", logout),
-                Route("/{token}/", login_redirect),
+                Route("/{token}/", login_page, methods=["GET"]),
+                Route("/{token}/", login_post, methods=["POST"]),
             ],
         )
     ]

--- a/packages/initbot-web/src/initbot_web/templates/login.html
+++ b/packages/initbot-web/src/initbot_web/templates/login.html
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Initiative Tracker — Log In</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='6' y='6' width='20' height='4' fill='%23b8860b'/><rect x='13' y='10' width='6' height='12' fill='%23b8860b'/><rect x='6' y='22' width='20' height='4' fill='%23b8860b'/></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --color-bg:   #f5f0e8;
+      --color-ink:  #1a1209;
+      --color-gold: #b8860b;
+      --font-main:  'Cinzel', Georgia, serif;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: var(--color-bg);
+      color: var(--color-ink);
+      font-family: var(--font-main);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .card {
+      text-align: center;
+      padding: 2rem 3rem;
+    }
+    h1 {
+      font-size: 1.4rem;
+      color: var(--color-gold);
+      margin-bottom: 1.5rem;
+    }
+    button {
+      font-family: var(--font-main);
+      font-size: 1rem;
+      background: var(--color-gold);
+      color: var(--color-bg);
+      border: none;
+      padding: 0.6rem 1.6rem;
+      cursor: pointer;
+      border-radius: 3px;
+    }
+    button:hover { opacity: 0.85; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Initiative Tracker</h1>
+    <form method="post">
+      <button type="submit">Log In</button>
+    </form>
+  </div>
+  <script>document.forms[0].submit();</script>
+</body>
+</html>

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+
+from initbot_core.config import CORE_CFG
+
+
+@pytest.fixture(autouse=True)
+def _clear_domain(monkeypatch):
+    # Ensure https_only=False for all web tests so the httpx TestClient
+    # (http://testserver) sends session cookies. A DOMAIN set in .env would
+    # make cookies Secure, which httpx won't send over plain HTTP.
+    monkeypatch.setattr(CORE_CFG, "domain", "")

--- a/tests/web/test_tracker.py
+++ b/tests/web/test_tracker.py
@@ -29,7 +29,7 @@ def _client(app):
 def _authed_client(app):
     """Client with an active session obtained via the shared admin token."""
     with TestClient(app, follow_redirects=False) as client:
-        client.get(
+        client.post(
             "/testsecret/testsecret/"
         )  # sets session cookie in client's cookie jar
         yield client
@@ -38,14 +38,43 @@ def _authed_client(app):
 # ── Login flow ────────────────────────────────────────────────────────────────
 
 
-def test_valid_token_redirects_to_tracker(client):
+def test_login_get_shows_form(client):
     resp = client.get("/testsecret/testsecret/")
-    assert resp.status_code == 302
+    assert resp.status_code == 200
+    assert "Log In" in resp.text
+
+
+def test_login_get_does_not_consume_token(tmp_path):
+    """GET must not consume the token — bots (e.g. Discordbot) issue GET requests."""
+    db_path = tmp_path / "test.db"
+    state = create_state_from_source(f"sqlite:{db_path}")
+    player = state.players.upsert(discord_id=42, name="Alice")
+    assert player.discord_id is not None
+    token = state.web_login_tokens.create(discord_id=player.discord_id)
+
+    settings = WebSettings(state=f"sqlite:{db_path}")
+    app = create_app(settings, web_url_path_prefix="admintoken")
+    with TestClient(app, follow_redirects=False) as client:
+        resp_get = client.get(f"/admintoken/{token}/")
+        assert resp_get.status_code == 200  # login page, token NOT consumed
+        resp_post = client.post(f"/admintoken/{token}/")
+        assert resp_post.status_code == 303  # token consumed here
+        assert resp_post.headers["location"] == "/admintoken/tracker/"
+
+
+def test_login_post_redirects_to_tracker(client):
+    resp = client.post("/testsecret/testsecret/")
+    assert resp.status_code == 303
     assert resp.headers["location"] == "/testsecret/tracker/"
 
 
-def test_invalid_token_returns_403(client):
+def test_login_get_invalid_token_returns_403(client):
     resp = client.get("/testsecret/wrongsecret/")
+    assert resp.status_code == 403
+
+
+def test_login_post_invalid_token_returns_403(client):
+    resp = client.post("/testsecret/wrongsecret/")
     assert resp.status_code == 403
 
 
@@ -78,7 +107,7 @@ def test_tracker_page_shows_player_name(tmp_path):
     settings = WebSettings(state=f"sqlite:{db_path}")
     app = create_app(settings, web_url_path_prefix="admintoken")
     with TestClient(app, follow_redirects=False) as client:
-        client.get(f"/admintoken/{token}/")
+        client.post(f"/admintoken/{token}/")
         resp = client.get("/admintoken/tracker/", follow_redirects=False)
         assert resp.status_code == 200
         assert "Alice" in resp.text
@@ -111,8 +140,8 @@ def test_per_player_token_creates_session(tmp_path):
     settings = WebSettings(state=f"sqlite:{db_path}")
     app = create_app(settings, web_url_path_prefix="admintoken")
     with TestClient(app, follow_redirects=False) as client:
-        resp = client.get(f"/admintoken/{token}/")
-        assert resp.status_code == 302
+        resp = client.post(f"/admintoken/{token}/")
+        assert resp.status_code == 303
         assert resp.headers["location"] == "/admintoken/tracker/"
         resp2 = client.get("/admintoken/tracker/", follow_redirects=False)
         assert resp2.status_code == 200
@@ -129,9 +158,11 @@ def test_used_token_returns_403(tmp_path):
     settings = WebSettings(state=f"sqlite:{db_path}")
     app = create_app(settings, web_url_path_prefix="admintoken")
     with TestClient(app, follow_redirects=False) as client:
-        client.get(f"/admintoken/{token}/")  # first use — consumes the token
-        resp = client.get(f"/admintoken/{token}/")  # second use — should fail
-        assert resp.status_code == 403
+        client.post(f"/admintoken/{token}/")  # first use — consumes the token
+        resp_get = client.get(f"/admintoken/{token}/")  # GET after use — should fail
+        assert resp_get.status_code == 403
+        resp_post = client.post(f"/admintoken/{token}/")  # POST after use — should fail
+        assert resp_post.status_code == 403
 
 
 # ── Session expiry & logout ───────────────────────────────────────────────────
@@ -140,7 +171,7 @@ def test_used_token_returns_403(tmp_path):
 def test_expired_session_returns_403(app, monkeypatch):
     future = time.time() + tracker_module.SESSION_TTL + 1
     with TestClient(app, follow_redirects=False) as client:
-        client.get("/testsecret/testsecret/")  # log in (session written at real now)
+        client.post("/testsecret/testsecret/")  # log in
         monkeypatch.setattr(tracker_module.time, "time", lambda: future)
         resp = client.get("/testsecret/tracker/")
         assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- Discord's Discordbot/2.0 crawler was consuming one-time login tokens by issuing a GET request to every URL posted in DMs, leaving the token used before the actual user clicked the link
- Split the login endpoint into GET (validates token, renders an auto-submit form — token intact) and POST (consumes token, writes session, redirects to tracker)
- Added `tests/web/conftest.py` with an autouse fixture that clears `DOMAIN` so `https_only=False` in tests (httpx TestClient won't send Secure cookies over HTTP)
- Fixed `run_web_dev.sh` dev script (was using a `user` field that no longer exists in the character model)

## Test plan

- [ ] All pre-commit hooks pass (`bash tools/precommit.sh`)
- [ ] Manual: start dev server with `tools/run_web_dev.sh`, visit `http://localhost:8080/dev/dev/`, confirm auto-redirect to tracker
- [ ] Manual: curl GET the login URL, confirm 200 is returned and token remains valid for a subsequent POST