### PR TITLE
Add $rename command for character renaming

### DIFF
--- a/packages/initbot-chat/src/initbot_chat/commands/__init__.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/__init__.py
@@ -12,6 +12,7 @@ from initbot_chat.commands.character import (
     init_dice,
     prune,
     remove,
+    rename,
     touch,
     unused,
 )
@@ -30,6 +31,7 @@ commands: Set[Any] = frozenset((
     init_dice,
     prune,
     remove,
+    rename,
     roll,
     touch,
     tarot,

--- a/packages/initbot-chat/src/initbot_chat/commands/character.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/character.py
@@ -70,6 +70,36 @@ async def init_dice(ctx: commands.Context, *args: str) -> None:
     await ctx.send(f"{cdi.name}'s initiative dice is now {spec}", delete_after=3)
 
 
+@commands.command(usage="[current name] <new name>")
+async def rename(ctx: commands.Context, *args: str) -> None:
+    """Rename your (or someone else's) character.
+
+    You can specify a character to rename or omit it.
+    If you manage only a single character, omit it: `$rename Alex` changes the name of your current character to Alex.
+    If you manage more than one character or want to rename someone else's character, add their name: `$rename Mel Alex` renames Mel to Alex
+
+    The first character name can be an abbreviation.
+    For example, if the full name of a character is "Mediocre Mel", then typing "med" is sufficient: `$rename med Alex`
+
+    The new name needs to be one word (no spaces).
+    """
+    player = sync_player(ctx.bot.initbot_state, ctx)
+    tokens = list(args)
+    if not tokens:
+        raise ValueError(
+            "Please provide a new name, e.g. `$rename Alex` or `$rename Med Alex`"
+        )
+    new_name = tokens[-1]
+    old_tokens = tokens[:-1]
+    cdi: CharacterData = ctx.bot.initbot_state.characters.get_from_tokens(
+        old_tokens, create=False, player_id=player.id
+    )
+    old_name = cdi.name
+    ctx.bot.initbot_state.character_actions.rename_character(old_name, new_name)
+    cdi = ctx.bot.initbot_state.characters.rename_and_store(cdi, new_name)
+    await ctx.send(f"Renamed {old_name} to {cdi.name}", delete_after=3)
+
+
 @commands.command(usage="[character name]")
 async def remove(ctx: commands.Context, *args: str) -> None:
     """Removes a character from the bot.
@@ -204,6 +234,7 @@ async def touch(ctx: commands.Context, *args: str) -> None:
 
 
 @init_dice.error
+@rename.error
 @remove.error
 @chars.error
 @char.error

--- a/packages/initbot-core/src/initbot_core/state/local.py
+++ b/packages/initbot-core/src/initbot_core/state/local.py
@@ -84,6 +84,17 @@ class LocalCharacterState(CharacterState):
         self._characters.remove(char_data)
         self._store()
 
+    def _rename_and_store(
+        self, char_data: CharacterData, new_name: str
+    ) -> CharacterData:
+        if not isinstance(char_data, LocalCharacterData):
+            raise TypeError(
+                f"Only character data returned by the State class can be renamed: {char_data}"
+            )
+        char_data.name = new_name
+        self._store()
+        return char_data
+
     def update_and_store(self, char_data: CharacterData) -> None:
         if not isinstance(char_data, LocalCharacterData):
             raise TypeError(
@@ -157,6 +168,9 @@ class LocalCharacterActionState(CharacterActionState):
             self._character_state.update_and_store(char)
         except KeyError:
             pass
+
+    def rename_character(self, old_name: str, new_name: str) -> None:
+        pass  # Actions are embedded in LocalCharacterData; renaming the character handles this
 
     def import_from(self, src: CharacterActionState) -> None:
         raise NotImplementedError()

--- a/packages/initbot-core/src/initbot_core/state/sql.py
+++ b/packages/initbot-core/src/initbot_core/state/sql.py
@@ -57,6 +57,14 @@ class _SqlCharacterState(CharacterState):
             _SqlCharacterData.name == char_data.name
         ).execute()
 
+    def _rename_and_store(
+        self, char_data: CharacterData, new_name: str
+    ) -> CharacterData:
+        _SqlCharacterData.update(name=new_name).where(
+            _SqlCharacterData.name == char_data.name
+        ).execute()
+        return _SqlCharacterData.get(_SqlCharacterData.name == new_name)  # type: ignore[return-value]
+
     def update_and_store(self, char_data: CharacterData) -> None:
         if not isinstance(char_data, _SqlCharacterData):
             raise TypeError(
@@ -184,6 +192,11 @@ class _SqlCharacterActionState(CharacterActionState):
     def remove_all_for_character(self, character_name: str) -> None:
         _SqlCharacterAction.delete().where(
             _SqlCharacterAction.character_name == character_name
+        ).execute()
+
+    def rename_character(self, old_name: str, new_name: str) -> None:
+        _SqlCharacterAction.update(character_name=new_name).where(
+            _SqlCharacterAction.character_name == old_name
         ).execute()
 
     def import_from(self, src: CharacterActionState) -> None:

--- a/packages/initbot-core/src/initbot_core/state/state.py
+++ b/packages/initbot-core/src/initbot_core/state/state.py
@@ -83,8 +83,26 @@ class CharacterState(PartialState, ABC):
                 )
         return self._add_store_and_get(char_data)
 
+    def rename_and_store(
+        self, char_data: CharacterData, new_name: str
+    ) -> CharacterData:
+        normalized = normalize_str(new_name)
+        for existing in self.get_all():
+            if normalize_str(existing.name) == normalized:
+                raise ValueError(
+                    f"A character named '{existing.name}' already exists "
+                    f"(character names must be unique ignoring case)"
+                )
+        return self._rename_and_store(char_data, new_name)
+
     @abstractmethod
     def _add_store_and_get(self, char_data: NewCharacterData) -> CharacterData:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _rename_and_store(
+        self, char_data: CharacterData, new_name: str
+    ) -> CharacterData:
         raise NotImplementedError()
 
     @abstractmethod
@@ -180,6 +198,11 @@ class CharacterActionState(PartialState, ABC):
     @abstractmethod
     def remove_all_for_character(self, character_name: str) -> None:
         """Delete every action belonging to the given character."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def rename_character(self, old_name: str, new_name: str) -> None:
+        """Update the character_name key for all actions belonging to old_name."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/tests/test_commands_chars.py
+++ b/tests/test_commands_chars.py
@@ -5,7 +5,7 @@
 import pytest
 from discord.ext import commands
 
-from initbot_chat.commands.character import char, char_error, chars, remove
+from initbot_chat.commands.character import char, char_error, chars, remove, rename
 from initbot_core.data.character import NewCharacterData
 
 
@@ -74,3 +74,72 @@ async def test_duplicate_name_exact_rejected(mock_ctx):
         mock_ctx.bot.initbot_state.characters.add_store_and_get(
             NewCharacterData(name="Foo", player_id=mock_ctx.author.player_id)
         )
+
+
+async def test_rename_single_character(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Mel", player_id=mock_ctx.author.player_id)
+    )
+    await rename.callback(mock_ctx, "Zara")
+    mock_ctx.send.assert_called()
+    msg = mock_ctx.send.call_args[0][0]
+    assert "Zara" in msg
+    names = [c.name for c in mock_ctx.bot.initbot_state.characters.get_all()]
+    assert "Zara" in names
+    assert "Mel" not in names
+
+
+async def test_rename_by_exact_name(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Alpha", player_id=mock_ctx.author.player_id)
+    )
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Beta", player_id=mock_ctx.author.player_id)
+    )
+    await rename.callback(mock_ctx, "Alpha", "Gamma")
+    names = [c.name for c in mock_ctx.bot.initbot_state.characters.get_all()]
+    assert "Gamma" in names
+    assert "Alpha" not in names
+    assert "Beta" in names
+
+
+async def test_rename_by_prefix(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Mediocre Mel", player_id=mock_ctx.author.player_id)
+    )
+    await rename.callback(mock_ctx, "Med", "Zara")
+    names = [c.name for c in mock_ctx.bot.initbot_state.characters.get_all()]
+    assert "Zara" in names
+    assert "Mediocre Mel" not in names
+
+
+async def test_rename_conflict_rejected(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Alpha", player_id=mock_ctx.author.player_id)
+    )
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Beta", player_id=mock_ctx.author.player_id)
+    )
+    with pytest.raises(ValueError, match="Beta"):
+        await rename.callback(mock_ctx, "Alpha", "Beta")
+
+
+async def test_rename_conflict_case_insensitive(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Alpha", player_id=mock_ctx.author.player_id)
+    )
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Beta", player_id=mock_ctx.author.player_id)
+    )
+    with pytest.raises(ValueError, match="Beta"):
+        await rename.callback(mock_ctx, "Alpha", "beta")
+
+
+async def test_rename_preserves_actions(mock_ctx):
+    cdi = mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Mel", player_id=mock_ctx.author.player_id)
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(cdi.name, "Stab {target}")
+    await rename.callback(mock_ctx, "Zara")
+    actions = mock_ctx.bot.initbot_state.character_actions.get_all_for_character("Zara")
+    assert list(actions) == ["Stab {target}"]


### PR DESCRIPTION
## Summary

- Adds `$rename [current name] <new name>` command following the existing `$init_dice` pattern: all-but-last tokens identify the character (optional for single-character players, supports prefix matching), last token is the new name
- Adds `rename_and_store` / `_rename_and_store` to `CharacterState` with case-insensitive uniqueness check in the base class and backend-specific implementations (SQL: UPDATE on primary key; local: mutate field + serialize)
- Adds `rename_character` to `CharacterActionState` so SQL action rows referencing the old name are updated atomically with the character rename; local backend is a no-op since actions are embedded
- 6 new tests covering: single-character rename, rename by exact name, rename by prefix, conflict rejection (exact and case-insensitive), and action preservation across rename