### PR TITLE
Generate random admin token separate from URL path prefix

### DIFF
--- a/packages/initbot-web/src/initbot_web/app.py
+++ b/packages/initbot-web/src/initbot_web/app.py
@@ -72,9 +72,10 @@ def create_app(
     # Ephemeral signing key: sessions are invalidated on app restart, which is acceptable.
     session_secret = secrets.token_urlsafe(32)
     https_only = bool(CORE_CFG.domain)
+    admin_token = secrets.token_urlsafe(32)
 
-    return Starlette(
-        routes=make_routes(state, templates, url_path_prefix, vuln_state),
+    app = Starlette(
+        routes=make_routes(state, templates, url_path_prefix, vuln_state, admin_token),
         middleware=[
             Middleware(
                 SessionMiddleware,  # type: ignore[invalid-argument-type]  # SessionMiddleware satisfies _MiddlewareFactory
@@ -85,16 +86,21 @@ def create_app(
         ],
         lifespan=lifespan,
     )
+    app.state.admin_token = admin_token
+    app.state.url_path_prefix = url_path_prefix
+    return app
 
 
 def run() -> None:
     cfg = WebSettings(_cli_parse_args=True)  # type: ignore
-    prefix = CORE_CFG.web_url_path_prefix or secrets.token_urlsafe(32)
-    print(f"URL: http://localhost:{cfg.web_port}/{prefix}/{prefix}/")
+    app = create_app(cfg)
+    prefix = app.state.url_path_prefix
+    admin_token = app.state.admin_token
+    print(f"URL: http://localhost:{cfg.web_port}/{prefix}/{admin_token}/")
     if CORE_CFG.domain:
-        print(f"External URL: https://{CORE_CFG.domain}/{prefix}/{prefix}/")
+        print(f"External URL: https://{CORE_CFG.domain}/{prefix}/{admin_token}/")
     uvicorn.run(
-        create_app(cfg, web_url_path_prefix=prefix),
+        app,
         host=cfg.web_host,
         port=cfg.web_port,
     )

--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -54,6 +54,7 @@ def make_routes(
     templates: Jinja2Templates,
     url_path_prefix: str,
     vuln_state: VulnerabilityState,
+    admin_token: str,
 ) -> list[Mount]:
     tracker_url = f"/{url_path_prefix}/tracker/"
     sse_url = f"/{url_path_prefix}/tracker/sse"
@@ -71,7 +72,7 @@ def make_routes(
             request.headers.get("x-forwarded-proto", "<absent>"),
         )
         is_player_token = state.web_login_tokens.find_valid(token) is not None
-        is_admin_token = bool(url_path_prefix) and token == url_path_prefix
+        is_admin_token = token == admin_token
         if not (is_player_token or is_admin_token):
             _log.warning("login GET: invalid or already-used token")
             return Response(status_code=403)
@@ -93,7 +94,7 @@ def make_routes(
                 list(request.session.keys()),
             )
             return RedirectResponse(tracker_url, status_code=303)
-        if url_path_prefix and token == url_path_prefix:
+        if token == admin_token:
             _write_session(request, None, None)
             _log.info(
                 "login POST: admin session written session_keys=%s",

--- a/tests/web/test_tracker.py
+++ b/tests/web/test_tracker.py
@@ -30,7 +30,7 @@ def _authed_client(app):
     """Client with an active session obtained via the shared admin token."""
     with TestClient(app, follow_redirects=False) as client:
         client.post(
-            "/testsecret/testsecret/"
+            f"/testsecret/{app.state.admin_token}/"
         )  # sets session cookie in client's cookie jar
         yield client
 
@@ -38,8 +38,8 @@ def _authed_client(app):
 # ── Login flow ────────────────────────────────────────────────────────────────
 
 
-def test_login_get_shows_form(client):
-    resp = client.get("/testsecret/testsecret/")
+def test_login_get_shows_form(client, app):
+    resp = client.get(f"/testsecret/{app.state.admin_token}/")
     assert resp.status_code == 200
     assert "Log In" in resp.text
 
@@ -62,8 +62,8 @@ def test_login_get_does_not_consume_token(tmp_path):
         assert resp_post.headers["location"] == "/admintoken/tracker/"
 
 
-def test_login_post_redirects_to_tracker(client):
-    resp = client.post("/testsecret/testsecret/")
+def test_login_post_redirects_to_tracker(client, app):
+    resp = client.post(f"/testsecret/{app.state.admin_token}/")
     assert resp.status_code == 303
     assert resp.headers["location"] == "/testsecret/tracker/"
 
@@ -171,7 +171,7 @@ def test_used_token_returns_403(tmp_path):
 def test_expired_session_returns_403(app, monkeypatch):
     future = time.time() + tracker_module.SESSION_TTL + 1
     with TestClient(app, follow_redirects=False) as client:
-        client.post("/testsecret/testsecret/")  # log in
+        client.post(f"/testsecret/{app.state.admin_token}/")  # log in
         monkeypatch.setattr(tracker_module.time, "time", lambda: future)
         resp = client.get("/testsecret/tracker/")
         assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- The admin login URL was `/{prefix}/{prefix}/`, making the token trivially guessable from the prefix visible in all player login links
- `create_app()` now generates a fresh `secrets.token_urlsafe(32)` admin token on every startup, stored on `app.state`
- `run()` reads the token from `app.state` and prints the full admin URL (`/{prefix}/{admin_token}/`) at startup — visible only to operators reading the log
- `make_routes()` checks `token == admin_token` instead of `token == url_path_prefix`