### PR TITLE
Accept commands in any case

### DIFF
--- a/packages/initbot-chat/src/initbot_chat/bot.py
+++ b/packages/initbot-chat/src/initbot_chat/bot.py
@@ -29,7 +29,11 @@ intents = Intents.default()
 intents.message_content = True
 
 # pylint: disable=no-member
-bot = Bot(command_prefix=tuple(CFG.command_prefixes.split(",")), intents=intents)
+bot = Bot(
+    command_prefix=tuple(CFG.command_prefixes.split(",")),
+    case_insensitive=True,
+    intents=intents,
+)
 
 _STARTUP_FAILED: bool = False
 
@@ -182,7 +186,7 @@ async def on_message(message: discord.Message) -> None:
         "".join(parts) for parts in product(prefixes, command_names)
     )
     is_command = any(
-        message.content.startswith(prefixed_command)
+        message.content.lower().startswith(prefixed_command)
         for prefixed_command in prefixed_commands
     )
 
@@ -195,7 +199,10 @@ async def on_message(message: discord.Message) -> None:
 
     if is_command:
         command = (
-            str(message.content).split(sep=None, maxsplit=1)[0].strip("".join(prefixes))
+            str(message.content)
+            .split(sep=None, maxsplit=1)[0]
+            .strip("".join(prefixes))
+            .lower()
         )
         if command not in frozenset(("actions", "init_dice", "roll")):
             message.content = result_text


### PR DESCRIPTION
## Summary

- Add `case_insensitive=True` to the `Bot` constructor so discord.py's internal dispatch accepts commands regardless of capitalisation
- Lowercase `message.content` before the `startswith` check in `on_message` so the custom command detection also matches `$Init`, `$INIT`, etc.
- Lowercase the extracted command name before the special-case `frozenset` comparison

## Test plan

- [ ] Send `$Init`, `$INIT`, `$iNiT` in Discord — all should behave identically to `$init`
- [ ] Send `$Rename`, `$ROLL 2d6`, `$Actions` — verify they work
- [ ] Send a plain message with dice notation (e.g. `roll 1d20`) — confirm inline dice roll still triggers (no regression)