### PR TITLE
Persist session signing secret across restarts

### DIFF
--- a/packages/initbot-core/src/initbot_core/state/local.py
+++ b/packages/initbot-core/src/initbot_core/state/local.py
@@ -18,6 +18,7 @@ from initbot_core.state.state import (
     CharacterActionState,
     CharacterState,
     PlayerState,
+    SessionSecretState,
     State,
     WebLoginTokenState,
 )
@@ -250,6 +251,14 @@ class _LocalWebLoginTokenState(WebLoginTokenState):
         raise NotImplementedError("Web login tokens require SQLite state")
 
 
+class _LocalSessionSecretState(SessionSecretState):
+    def _load(self) -> tuple[str, int] | None:
+        raise NotImplementedError("Session secrets require SQLite state")
+
+    def _store(self, secret: str, expires_at: int) -> None:
+        raise NotImplementedError("Session secrets require SQLite state")
+
+
 class LocalState(State):
     def __init__(self, source: str) -> None:
         source_dir = Path(source.split(":", maxsplit=1)[-1])
@@ -258,6 +267,7 @@ class LocalState(State):
         self._characters = LocalCharacterState(source_dir)
         self._web_login_tokens = _LocalWebLoginTokenState()
         self._character_actions = LocalCharacterActionState(self._characters)
+        self._session_secret = _LocalSessionSecretState()
 
     @property
     def characters(self) -> CharacterState:
@@ -274,6 +284,10 @@ class LocalState(State):
     @property
     def character_actions(self) -> CharacterActionState:
         return self._character_actions
+
+    @property
+    def session_secret(self) -> SessionSecretState:
+        return self._session_secret
 
     @classmethod
     def get_supported_state_types(cls) -> Set[str]:

--- a/packages/initbot-core/src/initbot_core/state/sql.py
+++ b/packages/initbot-core/src/initbot_core/state/sql.py
@@ -27,6 +27,7 @@ from initbot_core.state.state import (
     CharacterActionState,
     CharacterState,
     PlayerState,
+    SessionSecretState,
     State,
     WebLoginTokenState,
 )
@@ -249,6 +250,23 @@ class _SqlWebLoginTokenState(WebLoginTokenState):
         _SqlWebLoginToken.delete().where(_SqlWebLoginToken.expires_at <= now).execute()
 
 
+class _SqlSessionSecret(Model):
+    id = IntegerField(primary_key=True)  # single-row table; always id=1
+    secret = CharField()
+    expires_at = IntegerField()
+
+
+class _SqlSessionSecretState(SessionSecretState):
+    def _load(self) -> tuple[str, int] | None:
+        row = _SqlSessionSecret.get_or_none(_SqlSessionSecret.id == 1)
+        return (str(row.secret), int(row.expires_at)) if row is not None else None
+
+    def _store(self, secret: str, expires_at: int) -> None:
+        _SqlSessionSecret.insert(
+            id=1, secret=secret, expires_at=expires_at
+        ).on_conflict_replace().execute()
+
+
 class SqlState(State):
     def __init__(
         self,
@@ -258,6 +276,7 @@ class SqlState(State):
         self._players = _SqlPlayerState()
         self._web_login_tokens = _SqlWebLoginTokenState()
         self._character_actions = _SqlCharacterActionState()
+        self._session_secret = _SqlSessionSecretState()
 
         state_type, state_source = source.split(":", maxsplit=1)
         if state_type == "sqlite":
@@ -370,6 +389,10 @@ class SqlState(State):
     @property
     def character_actions(self) -> CharacterActionState:
         return self._character_actions
+
+    @property
+    def session_secret(self) -> SessionSecretState:
+        return self._session_secret
 
     @classmethod
     def get_supported_state_types(cls) -> Set[str]:

--- a/packages/initbot-core/src/initbot_core/state/state.py
+++ b/packages/initbot-core/src/initbot_core/state/state.py
@@ -2,8 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import secrets
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence, Set
+from typing import Final
 
 from initbot_core.data.character import CharacterData, NewCharacterData
 from initbot_core.data.player import PlayerData
@@ -210,6 +213,35 @@ class CharacterActionState(PartialState, ABC):
         raise NotImplementedError()
 
 
+_SESSION_SECRET_TTL: Final[int] = (
+    8 * 60 * 60
+)  # 8 hours, matches SESSION_TTL in initbot-web
+
+
+class SessionSecretState(ABC):
+    """Stores the persistent session-signing secret used by the web app."""
+
+    @abstractmethod
+    def _load(self) -> tuple[str, int] | None:
+        """Return (secret, expires_at) if a record exists, else None."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _store(self, secret: str, expires_at: int) -> None:
+        """Persist secret and expiry, replacing any existing record."""
+        raise NotImplementedError()
+
+    def get_or_rotate(self) -> str:
+        """Return the current secret, generating a new one if absent or expired."""
+        now = int(time.time())
+        entry = self._load()
+        if entry is not None and entry[1] > now:
+            return entry[0]
+        new_secret = secrets.token_urlsafe(32)
+        self._store(new_secret, now + _SESSION_SECRET_TTL)
+        return new_secret
+
+
 class State(ABC):
     @property
     @abstractmethod
@@ -229,6 +261,11 @@ class State(ABC):
     @property
     @abstractmethod
     def character_actions(self) -> CharacterActionState:
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def session_secret(self) -> SessionSecretState:
         raise NotImplementedError()
 
     def import_from(self, src: "State") -> None:

--- a/packages/initbot-web/src/initbot_web/app.py
+++ b/packages/initbot-web/src/initbot_web/app.py
@@ -69,8 +69,9 @@ def create_app(
         with suppress(CancelledError):
             await task
 
-    # Ephemeral signing key: sessions are invalidated on app restart, which is acceptable.
-    session_secret = secrets.token_urlsafe(32)
+    # Key rotation would be desirable (itsdangerous supports it via a list of secrets)
+    # but Starlette's SessionMiddleware only accepts a single secret_key at this point.
+    session_secret = state.session_secret.get_or_rotate()
     https_only = bool(CORE_CFG.domain)
     admin_token = secrets.token_urlsafe(32)
 

--- a/tests/test_session_secret.py
+++ b/tests/test_session_secret.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import pytest
+
+import initbot_core.state.state as state_module
+from initbot_core.state.factory import create_state_from_source
+from initbot_core.state.state import _SESSION_SECRET_TTL
+
+
+@pytest.fixture(name="state")
+def _state(tmp_path):
+    return create_state_from_source(f"sqlite:{tmp_path / 'test.db'}")
+
+
+def test_get_or_rotate_returns_string(state):
+    secret = state.session_secret.get_or_rotate()
+    assert isinstance(secret, str)
+    assert len(secret) > 0
+
+
+def test_get_or_rotate_returns_same_secret_when_unexpired(state):
+    secret1 = state.session_secret.get_or_rotate()
+    secret2 = state.session_secret.get_or_rotate()
+    assert secret1 == secret2
+
+
+def test_get_or_rotate_replaces_secret_when_expired(state, monkeypatch):
+    secret1 = state.session_secret.get_or_rotate()
+    future = int(state_module.time.time()) + _SESSION_SECRET_TTL + 1
+    monkeypatch.setattr(state_module.time, "time", lambda: future)
+    secret2 = state.session_secret.get_or_rotate()
+    assert secret2 != secret1
+
+
+def test_get_or_rotate_new_secret_is_stable_after_rotation(state, monkeypatch):
+    state.session_secret.get_or_rotate()
+    future = int(state_module.time.time()) + _SESSION_SECRET_TTL + 1
+    monkeypatch.setattr(state_module.time, "time", lambda: future)
+    secret2 = state.session_secret.get_or_rotate()
+    secret3 = state.session_secret.get_or_rotate()
+    assert secret2 == secret3

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 
+import shutil
 from pathlib import Path
 
 from initbot_core.state.factory import create_state_from_source
+
+_DATA_DIR = Path(__file__).parent / "data"
 
 
 def _check_state(state) -> None:
@@ -15,12 +18,12 @@ def _check_state(state) -> None:
 
 
 def test_load_json():
-    state = create_state_from_source(f"json:{Path(__file__).parent / 'data'}")
+    state = create_state_from_source(f"json:{_DATA_DIR}")
     _check_state(state)
 
 
-def test_load_sqlite():
-    state = create_state_from_source(
-        f"sqlite:{Path(__file__).parent / 'data' / 'test.sqlite'}"
-    )
+def test_load_sqlite(tmp_path):
+    db_copy = tmp_path / "test.sqlite"
+    shutil.copy2(_DATA_DIR / "test.sqlite", db_copy)
+    state = create_state_from_source(f"sqlite:{db_copy}")
     _check_state(state)

--- a/tests/web/test_tracker.py
+++ b/tests/web/test_tracker.py
@@ -7,8 +7,10 @@ import time
 import pytest
 from starlette.testclient import TestClient
 
+import initbot_core.state.state as state_module
 import initbot_web.routes.tracker as tracker_module
 from initbot_core.state.factory import create_state_from_source
+from initbot_core.state.state import _SESSION_SECRET_TTL
 from initbot_web.app import create_app
 from initbot_web.config import WebSettings
 
@@ -182,3 +184,39 @@ def test_logout_clears_session(authed_client):
     assert resp.status_code == 200
     resp2 = authed_client.get("/testsecret/tracker/")
     assert resp2.status_code == 403
+
+
+# ── Session secret persistence ────────────────────────────────────────────────
+
+
+def test_session_survives_restart(tmp_path):
+    """Session cookies remain valid when a new app instance reuses the unexpired secret."""
+    settings = WebSettings(state=f"sqlite:{tmp_path / 'test.db'}")
+    app1 = create_app(settings, web_url_path_prefix="testsecret")
+    with TestClient(app1, follow_redirects=False) as client1:
+        client1.post(f"/testsecret/{app1.state.admin_token}/")
+        cookies = dict(client1.cookies)
+
+    app2 = create_app(settings, web_url_path_prefix="testsecret")
+    with TestClient(app2, follow_redirects=False) as client2:
+        client2.cookies.update(cookies)
+        resp = client2.get("/testsecret/tracker/")
+        assert resp.status_code == 200
+
+
+def test_session_invalidated_after_secret_expiry(tmp_path, monkeypatch):
+    """Sessions are invalidated when the signing secret has expired and is rotated."""
+    settings = WebSettings(state=f"sqlite:{tmp_path / 'test.db'}")
+    app1 = create_app(settings, web_url_path_prefix="testsecret")
+    with TestClient(app1, follow_redirects=False) as client1:
+        client1.post(f"/testsecret/{app1.state.admin_token}/")
+        cookies = dict(client1.cookies)
+
+    future = int(time.time()) + _SESSION_SECRET_TTL + 1
+    monkeypatch.setattr(state_module.time, "time", lambda: future)
+
+    app2 = create_app(settings, web_url_path_prefix="testsecret")
+    with TestClient(app2, follow_redirects=False) as client2:
+        client2.cookies.update(cookies)
+        resp = client2.get("/testsecret/tracker/")
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- Adds `SessionSecretState` to the `initbot-core` state architecture, backed by a new `_SqlSessionSecret` table in SQLite
- On startup, the web app reuses the stored secret if unexpired (8h TTL matching `SESSION_TTL`), or generates and persists a new one if absent or expired — allowing client sessions to survive restarts without re-authentication via Discord
- Rotation logic (expiry check, secret generation) lives in the ABC; `_SqlSessionSecretState` only implements `_load`/`_store` CRUD primitives
- Adds a comment noting that key rotation via itsdangerous is desirable but not directly exposed by Starlette's `SessionMiddleware`
- Fixes `test_load_sqlite` to copy the fixture DB to `tmp_path`, preventing WAL-mode writes from dirtying the tracked file

## Test plan

- `test_session_survives_restart`: two app instances sharing the same DB — cookies from the first are valid in the second
- `test_session_invalidated_after_secret_expiry`: monkeypatches time past the TTL — second app issues a new secret, old cookies return 403
- `tests/test_session_secret.py`: unit tests for `get_or_rotate` (fresh creation, stability when unexpired, rotation when expired, stability after rotation)