### PR TITLE
Allow $act and $actions to search templates by string

### DIFF
--- a/packages/initbot-chat/src/initbot_chat/commands/actions.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/actions.py
@@ -25,6 +25,26 @@ def search_actions(templates: Sequence[str], terms: list[str]) -> list[tuple[int
     ]
 
 
+def _split_search_and_template(sub_args: list[str]) -> tuple[list[str], str]:
+    """Split sub_args into (search_terms, template) for keyword-based update.
+
+    Splits at the first token containing a dice roll: everything before it are
+    search terms; from that token onward is the new template.
+    Raises ValueError if no dice roll is found or no search terms precede it.
+    """
+    for i, token in enumerate(sub_args):
+        if contains_dice_rolls(token):
+            if i == 0:
+                raise ValueError(
+                    "Provide search words before the new template, "
+                    "e.g. `$actions update axe Mel swings at d20+6 for d12+5`"
+                )
+            return list(sub_args[:i]), " ".join(sub_args[i:])
+    raise ValueError(
+        "The new template must contain at least one dice roll (e.g. d20, 2d6+3)."
+    )
+
+
 def _split_actions_args(
     args: tuple[str, ...],
 ) -> tuple[list[str], str, list[str]]:
@@ -42,23 +62,30 @@ def _split_actions_args(
     )
 
 
+async def _send_no_match(
+    ctx: commands.Context, char_name: str, terms: list[str]
+) -> None:
+    terms_display = " ".join(terms)
+    await ctx.send(
+        f"No actions for {char_name} matched '{terms_display}'. "
+        f"Search checks whether each word appears anywhere in the action template "
+        f"(case-insensitive). Use `$actions list` to see all actions, "
+        f"or try fewer/different search terms.",
+        delete_after=10,
+    )
+
+
 async def _handle_search_result(
     ctx: commands.Context,
     char_name: str,
     matches: list[tuple[int, str]],
     terms: list[str],
 ) -> None:
-    terms_display = " ".join(terms)
     if not matches:
-        await ctx.send(
-            f"No actions for {char_name} matched '{terms_display}'. "
-            f"Search checks whether each word appears anywhere in the action template "
-            f"(case-insensitive). Use `$actions list` to see all actions, "
-            f"or try fewer/different search terms.",
-            delete_after=10,
-        )
+        await _send_no_match(ctx, char_name, terms)
         return
     if len(matches) > 1:
+        terms_display = " ".join(terms)
         await send_in_parts(
             ctx,
             (
@@ -98,15 +125,8 @@ async def _list_search_results(
         )
     templates = char_actions.get_all_for_character(char_name)
     matches = search_actions(templates, sub_args)
-    terms_display = " ".join(sub_args)
     if not matches:
-        await ctx.send(
-            f"No actions for {char_name} matched '{terms_display}'. "
-            f"Search checks whether each word appears anywhere in the action template "
-            f"(case-insensitive). Use `$actions list` to see all actions, "
-            f"or try fewer/different search terms.",
-            delete_after=10,
-        )
+        await _send_no_match(ctx, char_name, sub_args)
         return
     await send_in_parts(
         ctx,
@@ -115,6 +135,97 @@ async def _list_search_results(
             *(f"{i}. {t}" for i, t in matches),
         ),
     )
+
+
+async def _do_remove(
+    ctx: commands.Context,
+    char_actions: CharacterActionState,
+    char_name: str,
+    sub_args: list[str],
+) -> None:
+    if not sub_args:
+        raise ValueError("Usage: `$actions [character] remove NR|WORDS`")
+    templates = char_actions.get_all_for_character(char_name)
+    if sub_args[0].isdigit():
+        idx = int(sub_args[0])
+        if not 1 <= idx <= len(templates):
+            count = len(templates)
+            noun = "action" if count == 1 else "actions"
+            await ctx.send(
+                f"{char_name} only has {count} {noun}. Use `$actions list` to see them.",
+                delete_after=10,
+            )
+            return
+        char_actions.remove(char_name, idx)
+        await ctx.send(
+            f"Removed {char_name}'s action #{idx} ({templates[idx - 1]})",
+            delete_after=5,
+        )
+        return
+    matches = search_actions(templates, sub_args)
+    if not matches:
+        await _send_no_match(ctx, char_name, sub_args)
+        return
+    if len(matches) > 1:
+        terms_display = " ".join(sub_args)
+        await send_in_parts(
+            ctx,
+            (
+                f"Multiple actions for {char_name} matched '{terms_display}'. "
+                f"Use `$actions remove NR` with the action number to remove the one you want:",
+                *(f"{i}. {t}" for i, t in matches),
+            ),
+        )
+        return
+    idx, tmpl = matches[0]
+    char_actions.remove(char_name, idx)
+    await ctx.send(
+        f"Removed {char_name}'s action #{idx} ({tmpl})",
+        delete_after=5,
+    )
+
+
+async def _do_update(
+    ctx: commands.Context,
+    char_actions: CharacterActionState,
+    char_name: str,
+    sub_args: list[str],
+) -> None:
+    if not sub_args:
+        raise ValueError("Usage: `$actions [character] update NR|WORDS TEMPLATE`")
+    if sub_args[0].isdigit():
+        if len(sub_args) < 2:
+            raise ValueError("Usage: `$actions [character] update NR TEMPLATE`")
+        template = " ".join(sub_args[1:])
+        if not contains_dice_rolls(template):
+            raise ValueError(
+                f"Template must contain at least one dice roll (e.g. d20, 2d6+3). Got: '{template}'"
+            )
+        char_actions.update(char_name, int(sub_args[0]), template)
+        await ctx.send(
+            f"Updated action #{sub_args[0]} for {char_name}.", delete_after=5
+        )
+        return
+    search_terms, template = _split_search_and_template(sub_args)
+    templates = char_actions.get_all_for_character(char_name)
+    matches = search_actions(templates, search_terms)
+    if not matches:
+        await _send_no_match(ctx, char_name, search_terms)
+        return
+    if len(matches) > 1:
+        terms_display = " ".join(search_terms)
+        await send_in_parts(
+            ctx,
+            (
+                f"Multiple actions for {char_name} matched '{terms_display}'. "
+                f"Use `$actions update NR TEMPLATE` with the action number to update the one you want:",
+                *(f"{i}. {t}" for i, t in matches),
+            ),
+        )
+        return
+    idx, _ = matches[0]
+    char_actions.update(char_name, idx, template)
+    await ctx.send(f"Updated action #{idx} for {char_name}.", delete_after=5)
 
 
 @commands.command(
@@ -132,7 +243,9 @@ async def actions_cmd(ctx: commands.Context, *args: str) -> None:
     - list — show all actions a character knows, with their action numbers.
     - add TEMPLATE — add a new action template containing at least one dice roll.
     - update NR TEMPLATE — replace the template of the action with the given number.
+    - update WORDS TEMPLATE — replace the template of the action whose current template contains all of the given words. The new template begins at the first dice roll in your message. If more than one action matches, they are listed so you can pick by number.
     - remove NR — delete the action with the given number.
+    - remove WORDS — delete the action whose template contains all of the given words. If more than one action matches, they are listed so you can pick by number.
     - search WORDS — find actions whose template contains all of the given words (case-insensitive). Useful for discovering an action number when you remember part of the description but not the number.
 
     You can specify a character name or omit it.
@@ -167,34 +280,10 @@ async def actions_cmd(ctx: commands.Context, *args: str) -> None:
         await ctx.send(f"Added action #{index} for {cdi.name}.", delete_after=5)
 
     elif subcommand == "update":
-        if len(sub_args) < 2 or not sub_args[0].isdigit():
-            raise ValueError("Usage: `$actions [character] update IDX TEMPLATE`")
-        template = " ".join(sub_args[1:])
-        if not contains_dice_rolls(template):
-            raise ValueError(
-                f"Template must contain at least one dice roll (e.g. d20, 2d6+3). Got: '{template}'"
-            )
-        char_actions.update(cdi.name, int(sub_args[0]), template)
-        await ctx.send(f"Updated action #{sub_args[0]} for {cdi.name}.", delete_after=5)
+        await _do_update(ctx, char_actions, cdi.name, sub_args)
 
     elif subcommand == "remove":
-        if not sub_args or not sub_args[0].isdigit():
-            raise ValueError("Usage: `$actions [character] remove IDX`")
-        idx = int(sub_args[0])
-        templates = char_actions.get_all_for_character(cdi.name)
-        if not 1 <= idx <= len(templates):
-            count = len(templates)
-            noun = "action" if count == 1 else "actions"
-            await ctx.send(
-                f"{cdi.name} only has {count} {noun}. Use `$actions list` to see them.",
-                delete_after=10,
-            )
-            return
-        char_actions.remove(cdi.name, idx)
-        await ctx.send(
-            f"Removed {cdi.name}'s action #{sub_args[0]} ({templates[idx - 1]})",
-            delete_after=5,
-        )
+        await _do_remove(ctx, char_actions, cdi.name, sub_args)
 
     elif subcommand == "search":
         await _list_search_results(ctx, char_actions, cdi.name, sub_args)

--- a/packages/initbot-chat/src/initbot_chat/commands/actions.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/actions.py
@@ -3,14 +3,26 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
+from collections.abc import Sequence
 from typing import Final
 
 from discord.ext import commands
 
 from initbot_chat.commands.utils import send_in_parts, sync_player
 from initbot_core.models.roll import contains_dice_rolls, render_dice_rolls_in_text
+from initbot_core.state.state import CharacterActionState
 
-_SUBCOMMANDS: Final = frozenset({"list", "add", "update", "remove"})
+_SUBCOMMANDS: Final = frozenset({"list", "add", "update", "remove", "search"})
+
+
+def search_actions(templates: Sequence[str], terms: list[str]) -> list[tuple[int, str]]:
+    """Return (1-based index, template) pairs where every term is a case-insensitive substring."""
+    lower_terms = [t.lower() for t in terms]
+    return [
+        (i, tmpl)
+        for i, tmpl in enumerate(templates, start=1)
+        if all(term in tmpl.lower() for term in lower_terms)
+    ]
 
 
 def _split_actions_args(
@@ -25,9 +37,39 @@ def _split_actions_args(
         if token.lower() in _SUBCOMMANDS:
             return list(args[:i]), token.lower(), list(args[i + 1 :])
     raise ValueError(
-        "Usage: `$actions [character] list|add|update|remove [args]`\n"
+        "Usage: `$actions [character] list|add|update|remove|search [args]`\n"
         "Example: `$actions add Mel attacks at d20+3 for 2d6 damage`"
     )
+
+
+async def _handle_search_result(
+    ctx: commands.Context,
+    char_name: str,
+    matches: list[tuple[int, str]],
+    terms: list[str],
+) -> None:
+    terms_display = " ".join(terms)
+    if not matches:
+        await ctx.send(
+            f"No actions for {char_name} matched '{terms_display}'. "
+            f"Search checks whether each word appears anywhere in the action template "
+            f"(case-insensitive). Use `$actions list` to see all actions, "
+            f"or try fewer/different search terms.",
+            delete_after=10,
+        )
+        return
+    if len(matches) > 1:
+        await send_in_parts(
+            ctx,
+            (
+                f"Multiple actions for {char_name} matched '{terms_display}'. "
+                f"Refine your search or use the action number directly:",
+                *(f"{i}. {t}" for i, t in matches),
+            ),
+        )
+        return
+    _index, template = matches[0]
+    await ctx.send(render_dice_rolls_in_text(template))
 
 
 async def _list_actions(ctx: commands.Context, char_name: str) -> None:
@@ -44,8 +86,39 @@ async def _list_actions(ctx: commands.Context, char_name: str) -> None:
     )
 
 
+async def _list_search_results(
+    ctx: commands.Context,
+    char_actions: CharacterActionState,
+    char_name: str,
+    sub_args: list[str],
+) -> None:
+    if not sub_args:
+        raise ValueError(
+            "Provide search terms after `search`, e.g. `$actions search axe`"
+        )
+    templates = char_actions.get_all_for_character(char_name)
+    matches = search_actions(templates, sub_args)
+    terms_display = " ".join(sub_args)
+    if not matches:
+        await ctx.send(
+            f"No actions for {char_name} matched '{terms_display}'. "
+            f"Search checks whether each word appears anywhere in the action template "
+            f"(case-insensitive). Use `$actions list` to see all actions, "
+            f"or try fewer/different search terms.",
+            delete_after=10,
+        )
+        return
+    await send_in_parts(
+        ctx,
+        (
+            f"{char_name}'s matching actions:",
+            *(f"{i}. {t}" for i, t in matches),
+        ),
+    )
+
+
 @commands.command(
-    name="actions", usage="[character name] list|add|update|remove [args]"
+    name="actions", usage="[character name] list|add|update|remove|search [args]"
 )
 async def actions_cmd(ctx: commands.Context, *args: str) -> None:
     """Manage character actions.
@@ -53,13 +126,14 @@ async def actions_cmd(ctx: commands.Context, *args: str) -> None:
     Character actions are shortcuts for common dice rolls of a character.
     For example, your character may have two preferred attacks and you find yourself typing "Mediocre Mel attacks with an axe at d20+5 for d12+3 damage" and "Mediocre Mel attacks with a Javelin at d20+3 for d8+1 damage" again and again.
     Actions bring this down to `$act 1` and `$act 2` and the chat bot replies with the same responses as above, including resolving the dice rolls.
-    You just store those actions as templates ahead of time and can then use them by their action numbers.
+    You store those actions as templates ahead of time and can then run them by number or by searching for keywords.
 
     Subcommands:
-    - list — show the actions that a character knows (including their action numbers).
-    - add TEMPLATE — add a new action template containing at least one dice roll
-    - update NR TEMPLATE — change the template of the action with the given action number.
-    - remove NR — delete the action with the given action number.
+    - list — show all actions a character knows, with their action numbers.
+    - add TEMPLATE — add a new action template containing at least one dice roll.
+    - update NR TEMPLATE — replace the template of the action with the given number.
+    - remove NR — delete the action with the given number.
+    - search WORDS — find actions whose template contains all of the given words (case-insensitive). Useful for discovering an action number when you remember part of the description but not the number.
 
     You can specify a character name or omit it.
     If you manage only a single character, omit it: `$actions list`
@@ -122,45 +196,70 @@ async def actions_cmd(ctx: commands.Context, *args: str) -> None:
             delete_after=5,
         )
 
+    elif subcommand == "search":
+        await _list_search_results(ctx, char_actions, cdi.name, sub_args)
 
-@commands.command(name="act", usage="[character name] NR")
+
+@commands.command(name="act", usage="[character name] NR|WORDS")
 async def act_cmd(ctx: commands.Context, *args: str) -> None:
     """Run an action of your or any other character.
 
     `$help actions` will get you started with character actions.
 
-    For this $act command, you always need to provide the action number of the action you want to run.
-    `$act` without an action number or `$actions list` tell you which actions a character knows and what their action numbers are.
+    You can run an action by its number or by searching for it with keywords:
+    - By number: `$act 1` runs action #1. Use `$actions list` to see all numbers.
+    - By keyword: `$act axe` searches for an action whose template contains "axe". If exactly one action matches, it runs immediately. If multiple match, they are listed so you can pick by number. Search is case-insensitive and all words must match: `$act axe d12` only matches templates that contain both "axe" and "d12".
 
     You can specify a character name or omit it.
-    If you manage only a single character, omit it: `$act 1`
-    If you manage more than one character or want to run an action of someone else's character, include the name: `$act Mediocre Mel 1`
+    If you manage only a single character, omit it: `$act 1` or `$act axe`
+    If you manage more than one character or want to run an action of someone else's character, include the name before the number or keywords: `$act Mediocre Mel 1` or `$act Mediocre Mel axe`
 
     The character name can be an abbreviation.
-    For example, if the full name of a character is "Mediocre Mel", then typing "med" is sufficient: `$act med 1`
+    For example, if the full name of a character is "Mediocre Mel", then typing "med" is sufficient: `$act med 1` or `$act med axe`
     """
     player = sync_player(ctx.bot.initbot_state, ctx)
     state = ctx.bot.initbot_state
 
-    if not args or not args[-1].isdigit():
-        cdi = state.characters.get_from_tokens(
-            list(args), ctx.author.name, player_id=player.id
-        )
+    if not args:
+        cdi = state.characters.get_from_tokens([], ctx.author.name, player_id=player.id)
         await _list_actions(ctx, cdi.name)
         return
 
-    index = int(args[-1])
-    cdi = state.characters.get_from_tokens(
-        list(args[:-1]), ctx.author.name, player_id=player.id
-    )
+    if args[-1].isdigit():
+        index = int(args[-1])
+        cdi = state.characters.get_from_tokens(
+            list(args[:-1]), ctx.author.name, player_id=player.id
+        )
+        templates = state.character_actions.get_all_for_character(cdi.name)
+        if not 1 <= index <= len(templates):
+            raise ValueError(
+                f"{cdi.name} has {len(templates)} action(s); index {index} is out of range."
+            )
+        await ctx.send(render_dice_rolls_in_text(templates[index - 1]))
+        return
+
+    # Use create=False in the probe to avoid accidentally creating characters from search terms.
+    search_terms: list[str] = []
+    name_tokens = list(args)
+    while name_tokens:
+        try:
+            cdi = state.characters.get_from_tokens(
+                name_tokens, create=False, player_id=player.id
+            )
+            break
+        except KeyError:
+            search_terms.insert(0, name_tokens.pop())
+    else:
+        search_terms = list(args)
+        cdi = state.characters.get_from_tokens([], ctx.author.name, player_id=player.id)
+
+    if not search_terms:
+        await _list_actions(ctx, cdi.name)
+        return
 
     templates = state.character_actions.get_all_for_character(cdi.name)
-    if not 1 <= index <= len(templates):
-        raise ValueError(
-            f"{cdi.name} has {len(templates)} action(s); index {index} is out of range."
-        )
-
-    await ctx.send(render_dice_rolls_in_text(templates[index - 1]))
+    matches = search_actions(templates, search_terms)
+    await _handle_search_result(ctx, cdi.name, matches, search_terms)
 
 
 @actions_cmd.error

--- a/tests/test_commands_actions.py
+++ b/tests/test_commands_actions.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from initbot_chat.commands.actions import act_cmd, actions_cmd
+from initbot_chat.commands.actions import act_cmd, actions_cmd, search_actions
 from initbot_chat.commands.character import prune, remove
 from initbot_core.data.character import NewCharacterData
 from initbot_core.models.roll import contains_dice_rolls
@@ -252,3 +252,183 @@ async def test_prune_cascades_actions(mock_ctx):
         "OldChar"
     )
     assert templates == []
+
+
+# ---------------------------------------------------------------------------
+# search_actions (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_search_actions_single_match():
+    templates = [
+        "Mel attacks with an axe at d20+5 for d12+3",
+        "Mel attacks with a javelin at d20+3 for d8+1",
+    ]
+    assert search_actions(templates, ["axe"]) == [(1, templates[0])]
+
+
+def test_search_actions_multiple_matches():
+    templates = [
+        "Mel attacks with an axe at d20+5 for d12+3",
+        "Mel attacks with a javelin at d20+3 for d8+1",
+    ]
+    assert search_actions(templates, ["attacks"]) == [
+        (1, templates[0]),
+        (2, templates[1]),
+    ]
+
+
+def test_search_actions_no_match():
+    templates = ["Mel attacks with an axe at d20+5"]
+    assert search_actions(templates, ["fireball"]) == []
+
+
+def test_search_actions_case_insensitive():
+    templates = ["Mel attacks with an Axe at d20+5"]
+    assert search_actions(templates, ["AXE"]) == [(1, templates[0])]
+    assert search_actions(templates, ["axe"]) == [(1, templates[0])]
+
+
+def test_search_actions_multi_term_and_semantics():
+    templates = [
+        "Mel attacks with an axe at d20+5 for d12+3",
+        "Mel attacks with a javelin at d20+3 for d8+1",
+    ]
+    assert search_actions(templates, ["javelin", "d8"]) == [(2, templates[1])]
+    assert search_actions(templates, ["attacks", "d20+5"]) == [(1, templates[0])]
+
+
+def test_search_actions_empty_templates():
+    assert search_actions([], ["axe"]) == []
+
+
+# ---------------------------------------------------------------------------
+# $act search mode
+# ---------------------------------------------------------------------------
+
+
+async def test_act_search_single_match_executes(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await act_cmd.callback(mock_ctx, "axe")
+    result = mock_ctx.send.call_args[0][0]
+    assert "Mel attacks with axe at" in result
+    assert not contains_dice_rolls(result)
+
+
+async def test_act_search_no_match_friendly_message(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    await act_cmd.callback(mock_ctx, "fireball")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "No actions" in msg
+    assert "fireball" in msg
+
+
+async def test_act_search_multiple_matches_lists_them(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await act_cmd.callback(mock_ctx, "attacks")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "axe" in all_msgs
+    assert "javelin" in all_msgs
+    assert "Multiple actions" in all_msgs
+
+
+async def test_act_search_with_character_prefix(mock_ctx):
+    _add_char(mock_ctx, name="Mediocre Mel")
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await act_cmd.callback(mock_ctx, "Med", "javelin")
+    result = mock_ctx.send.call_args[0][0]
+    assert "Mediocre Mel attacks with javelin" in result
+    assert not contains_dice_rolls(result)
+
+
+async def test_act_search_multi_term(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await act_cmd.callback(mock_ctx, "javelin", "attacks")
+    result = mock_ctx.send.call_args[0][0]
+    assert "javelin" in result
+    assert not contains_dice_rolls(result)
+
+
+# ---------------------------------------------------------------------------
+# $actions search subcommand
+# ---------------------------------------------------------------------------
+
+
+async def test_actions_search_single_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "search", "axe")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "axe" in all_msgs
+    assert "1." in all_msgs
+
+
+async def test_actions_search_no_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    await actions_cmd.callback(mock_ctx, "search", "fireball")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "No actions" in msg
+
+
+async def test_actions_search_multiple_matches(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "search", "attacks")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "1." in all_msgs
+    assert "2." in all_msgs
+
+
+async def test_actions_search_no_terms_raises(mock_ctx):
+    _add_char(mock_ctx)
+    with pytest.raises(ValueError, match="search terms"):
+        await actions_cmd.callback(mock_ctx, "search")
+
+
+async def test_actions_search_with_character_prefix(mock_ctx):
+    _add_char(mock_ctx, name="Mediocre Mel")
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with javelin at d20+3"
+    )
+    await actions_cmd.callback(mock_ctx, "Med", "search", "javelin")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "javelin" in all_msgs

--- a/tests/test_commands_actions.py
+++ b/tests/test_commands_actions.py
@@ -4,7 +4,12 @@
 
 import pytest
 
-from initbot_chat.commands.actions import act_cmd, actions_cmd, search_actions
+from initbot_chat.commands.actions import (
+    _split_search_and_template,
+    act_cmd,
+    actions_cmd,
+    search_actions,
+)
 from initbot_chat.commands.character import prune, remove
 from initbot_core.data.character import NewCharacterData
 from initbot_core.models.roll import contains_dice_rolls
@@ -432,3 +437,191 @@ async def test_actions_search_with_character_prefix(mock_ctx):
     await actions_cmd.callback(mock_ctx, "Med", "search", "javelin")
     all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
     assert "javelin" in all_msgs
+
+
+# ---------------------------------------------------------------------------
+# _split_search_and_template (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_split_search_and_template_basic():
+    assert _split_search_and_template(["axe", "d20+6"]) == (["axe"], "d20+6")
+
+
+def test_split_search_and_template_multi_word_template():
+    assert _split_search_and_template([
+        "axe",
+        "Mel",
+        "swings",
+        "at",
+        "d20+6",
+        "for",
+        "d12+5",
+    ]) == (["axe", "Mel", "swings", "at"], "d20+6 for d12+5")
+
+
+def test_split_search_and_template_multi_term_search():
+    assert _split_search_and_template(["axe", "attack", "d20+6"]) == (
+        ["axe", "attack"],
+        "d20+6",
+    )
+
+
+def test_split_search_and_template_no_search_terms_raises():
+    with pytest.raises(ValueError, match="search words"):
+        _split_search_and_template(["d20+6", "for", "d12"])
+
+
+def test_split_search_and_template_no_dice_raises():
+    with pytest.raises(ValueError, match="dice roll"):
+        _split_search_and_template(["axe", "attack", "Mel"])
+
+
+# ---------------------------------------------------------------------------
+# $actions remove — search mode
+# ---------------------------------------------------------------------------
+
+
+async def test_actions_remove_by_search_single_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "remove", "axe")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "Removed" in msg
+    assert "axe" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert len(templates) == 1
+    assert "javelin" in templates[0]
+
+
+async def test_actions_remove_by_search_no_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    await actions_cmd.callback(mock_ctx, "remove", "fireball")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "No actions" in msg
+    assert "fireball" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert len(templates) == 1
+
+
+async def test_actions_remove_by_search_multiple_matches(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "remove", "attacks")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "Multiple actions" in all_msgs
+    assert "$actions remove NR" in all_msgs
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert len(templates) == 2
+
+
+async def test_actions_remove_by_search_with_character_prefix(mock_ctx):
+    _add_char(mock_ctx, name="Mediocre Mel")
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with axe at d20+5"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with javelin at d20+3"
+    )
+    await actions_cmd.callback(mock_ctx, "Med", "remove", "axe")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "Removed" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mediocre Mel"
+    )
+    assert len(templates) == 1
+    assert "javelin" in templates[0]
+
+
+# ---------------------------------------------------------------------------
+# $actions update — search mode
+# ---------------------------------------------------------------------------
+
+
+async def test_actions_update_by_search_single_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "update", "axe", "d20+6", "for", "d12+5")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "Updated" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert "d20+6" in templates[0]
+    assert "d12+5" in templates[0]
+
+
+async def test_actions_update_by_search_no_match(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    await actions_cmd.callback(mock_ctx, "update", "fireball", "d20+6")
+    msg = mock_ctx.send.call_args[0][0]
+    assert "No actions" in msg
+    assert "fireball" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert "d20+5" in templates[0]
+
+
+async def test_actions_update_by_search_multiple_matches(mock_ctx):
+    _add_char(mock_ctx)
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with axe at d20+5 for d12+3"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mel", "Mel attacks with javelin at d20+3 for d8+1"
+    )
+    await actions_cmd.callback(mock_ctx, "update", "attacks", "d20+6")
+    all_msgs = " ".join(str(c) for c in mock_ctx.send.call_args_list)
+    assert "Multiple actions" in all_msgs
+    assert "$actions update NR TEMPLATE" in all_msgs
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mel"
+    )
+    assert len(templates) == 2
+
+
+async def test_actions_update_by_search_with_character_prefix(mock_ctx):
+    _add_char(mock_ctx, name="Mediocre Mel")
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with axe at d20+5"
+    )
+    mock_ctx.bot.initbot_state.character_actions.add(
+        "Mediocre Mel", "Mediocre Mel attacks with javelin at d20+3"
+    )
+    await actions_cmd.callback(
+        mock_ctx, "Med", "update", "javelin", "d20+4", "for", "d8+2"
+    )
+    msg = mock_ctx.send.call_args[0][0]
+    assert "Updated" in msg
+    templates = mock_ctx.bot.initbot_state.character_actions.get_all_for_character(
+        "Mediocre Mel"
+    )
+    assert any("d20+4" in t and "d8+2" in t for t in templates)


### PR DESCRIPTION
## Summary

- `$act <words>` now searches action templates by substring instead of requiring a number. Single match executes the action; multiple matches lists them with their numbers; no match gives a friendly explanation of how search works.
- `$actions search <words>` new subcommand that always lists matching actions with their numbers — useful for discovering which number to use as an unambiguous fallback.
- Action numbers (`$act 1`, `$act 2`, …) continue to work exactly as before.

## Search semantics

Case-insensitive, all supplied words must appear as substrings in the template (AND logic). Character name prefix still works: `$act Med javelin` resolves "Med" to the character and searches for "javelin".

## Test plan

- [ ] `search_actions` pure-function unit tests (single/multiple/no match, case insensitivity, multi-term AND, empty list)
- [ ] `$act <term>` — single match executes, multiple matches lists, no match friendly message
- [ ] `$act <char prefix> <term>` — character resolved, term searched
- [ ] `$actions search <terms>` — lists matches with numbers, no match message, no terms raises error, character prefix supported
- [ ] All existing `$act` / `$actions` tests still pass