### PR TITLE
Implement missing local/json data store functionality

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -181,5 +181,5 @@ jobs:
           severity: CRITICAL,HIGH
       - name: "Verify chat: invalid token raises LoginFailure"
         run: sh tools/test/docker_chat.sh
-      - name: "Verify web: missing SQLite state raises SystemExit"
+      - name: "Verify web: unknown state type raises error"
         run: sh tools/test/docker_web.sh

--- a/packages/initbot-core/src/initbot_core/state/local.py
+++ b/packages/initbot-core/src/initbot_core/state/local.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
+import secrets
 import time
 from collections.abc import Mapping, MutableSequence, Sequence, Set
 from dataclasses import asdict
@@ -15,6 +16,7 @@ from initbot_core.config import CORE_CFG
 from initbot_core.data.character import CharacterData, NewCharacterData
 from initbot_core.data.player import PlayerData
 from initbot_core.state.state import (
+    _WEB_LOGIN_TOKEN_TTL,
     CharacterActionState,
     CharacterState,
     PlayerState,
@@ -114,7 +116,17 @@ class LocalCharacterState(CharacterState):
             )
 
     def import_from(self, src: CharacterState) -> None:
-        raise NotImplementedError()
+        for cdi in src.get_all():
+            self._characters.append(
+                LocalCharacterData(
+                    name=cdi.name,
+                    player_id=cdi.player_id,
+                    initiative=cdi.initiative,
+                    initiative_dice=cdi.initiative_dice,
+                    last_used=cdi.last_used,
+                )
+            )
+        self._store()
 
 
 class LocalCharacterActionState(CharacterActionState):
@@ -174,7 +186,11 @@ class LocalCharacterActionState(CharacterActionState):
         pass  # Actions are embedded in LocalCharacterData; renaming the character handles this
 
     def import_from(self, src: CharacterActionState) -> None:
-        raise NotImplementedError()
+        for char in self._character_state.get_all():
+            templates = src.get_all_for_character(char.name)
+            if templates and isinstance(char, LocalCharacterData):
+                char.actions = list(templates)
+        self._character_state._store()  # pylint: disable=protected-access
 
 
 class LocalPlayerData(LocalBaseModel):
@@ -234,29 +250,90 @@ class LocalPlayerState(PlayerState):
             file_desc.write(LocalPlayersData(players=self._players).model_dump_json())
 
     def import_from(self, src: PlayerState) -> None:
-        raise NotImplementedError()
+        for p in src.get_all():
+            self._players.append(
+                LocalPlayerData(id=p.id, discord_id=p.discord_id, name=p.name)
+            )
+        self._store()
+
+
+class _LocalWebLoginTokenData(LocalBaseModel):
+    discord_id: int
+    expires_at: int
+    used: bool = False
+
+
+class _LocalWebLoginTokensData(LocalBaseModel):
+    tokens: dict[str, _LocalWebLoginTokenData] = {}
 
 
 class _LocalWebLoginTokenState(WebLoginTokenState):
+    def __init__(self, source_dir: Path) -> None:
+        self._path: Final[Path] = source_dir / "web_login_tokens.json"
+        tokens_data = _LocalWebLoginTokensData()
+        if self._path.exists():
+            with self._path.open() as file_desc:
+                tokens_data = _LocalWebLoginTokensData.model_validate_json(
+                    file_desc.read()
+                )
+        self._tokens: dict[str, _LocalWebLoginTokenData] = tokens_data.tokens
+
+    def _store(self) -> None:
+        with open(self._path, "w", encoding="UTF8") as file_desc:
+            file_desc.write(
+                _LocalWebLoginTokensData(tokens=self._tokens).model_dump_json()
+            )
+
     def create(self, discord_id: int) -> str:
-        raise NotImplementedError("Web login tokens require SQLite state")
+        token = secrets.token_urlsafe(32)
+        self._tokens[token] = _LocalWebLoginTokenData(
+            discord_id=discord_id,
+            expires_at=int(time.time()) + _WEB_LOGIN_TOKEN_TTL,
+        )
+        self._store()
+        return token
 
     def find_valid(self, token: str) -> int | None:
-        raise NotImplementedError("Web login tokens require SQLite state")
+        entry = self._tokens.get(token)
+        if entry is None or entry.used or entry.expires_at <= int(time.time()):
+            return None
+        return entry.discord_id
 
     def mark_used(self, token: str) -> None:
-        raise NotImplementedError("Web login tokens require SQLite state")
+        entry = self._tokens.get(token)
+        if entry is not None:
+            entry.used = True
+            self._store()
 
     def prune_expired(self) -> None:
-        raise NotImplementedError("Web login tokens require SQLite state")
+        now = int(time.time())
+        expired = [t for t, e in self._tokens.items() if e.expires_at <= now]
+        for t in expired:
+            del self._tokens[t]
+        if expired:
+            self._store()
+
+
+class _LocalSessionSecretData(LocalBaseModel):
+    secret: str
+    expires_at: int
 
 
 class _LocalSessionSecretState(SessionSecretState):
+    def __init__(self, source_dir: Path) -> None:
+        self._path: Final[Path] = source_dir / "session_secret.json"
+
     def _load(self) -> tuple[str, int] | None:
-        raise NotImplementedError("Session secrets require SQLite state")
+        if not self._path.exists():
+            return None
+        with self._path.open() as file_desc:
+            data = _LocalSessionSecretData.model_validate_json(file_desc.read())
+        return data.secret, data.expires_at
 
     def _store(self, secret: str, expires_at: int) -> None:
-        raise NotImplementedError("Session secrets require SQLite state")
+        data = _LocalSessionSecretData(secret=secret, expires_at=expires_at)
+        with open(self._path, "w", encoding="UTF8") as file_desc:
+            file_desc.write(data.model_dump_json())
 
 
 class LocalState(State):
@@ -265,9 +342,9 @@ class LocalState(State):
         check_state_directory(source, source_dir)
         self._players = LocalPlayerState(source_dir)
         self._characters = LocalCharacterState(source_dir)
-        self._web_login_tokens = _LocalWebLoginTokenState()
+        self._web_login_tokens = _LocalWebLoginTokenState(source_dir)
         self._character_actions = LocalCharacterActionState(self._characters)
-        self._session_secret = _LocalSessionSecretState()
+        self._session_secret = _LocalSessionSecretState(source_dir)
 
     @property
     def characters(self) -> CharacterState:

--- a/packages/initbot-core/src/initbot_core/state/sql.py
+++ b/packages/initbot-core/src/initbot_core/state/sql.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Mapping, Sequence, Set
 from dataclasses import asdict
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any, cast
 
 from peewee import (
     AutoField,
@@ -24,6 +24,7 @@ from initbot_core.config import CORE_CFG
 from initbot_core.data.character import CharacterData, NewCharacterData
 from initbot_core.data.player import PlayerData
 from initbot_core.state.state import (
+    _WEB_LOGIN_TOKEN_TTL,
     CharacterActionState,
     CharacterState,
     PlayerState,
@@ -208,9 +209,6 @@ class _SqlCharacterActionState(CharacterActionState):
                     position=pos,
                     template=template,
                 )
-
-
-_WEB_LOGIN_TOKEN_TTL: Final[int] = 60  # seconds
 
 
 class _SqlWebLoginToken(Model):

--- a/packages/initbot-core/src/initbot_core/state/state.py
+++ b/packages/initbot-core/src/initbot_core/state/state.py
@@ -213,6 +213,8 @@ class CharacterActionState(PartialState, ABC):
         raise NotImplementedError()
 
 
+_WEB_LOGIN_TOKEN_TTL: Final[int] = 60  # seconds
+
 _SESSION_SECRET_TTL: Final[int] = (
     8 * 60 * 60
 )  # 8 hours, matches SESSION_TTL in initbot-web

--- a/packages/initbot-web/src/initbot_web/app.py
+++ b/packages/initbot-web/src/initbot_web/app.py
@@ -52,8 +52,6 @@ def create_app(
     settings: WebSettings | None = None, web_url_path_prefix: str | None = None
 ) -> Starlette:
     cfg = settings or WebSettings()
-    if not cfg.state.startswith("sqlite:"):
-        raise SystemExit(f"initbot-web requires a SQLite state URI. Got: {cfg.state!r}")
     state = create_state_from_source(cfg.state)
     templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
     vuln_state = VulnerabilityState()

--- a/tests/test_session_secret.py
+++ b/tests/test_session_secret.py
@@ -9,8 +9,10 @@ from initbot_core.state.factory import create_state_from_source
 from initbot_core.state.state import _SESSION_SECRET_TTL
 
 
-@pytest.fixture(name="state")
-def _state(tmp_path):
+@pytest.fixture(params=["json", "sqlite"], name="state")
+def _state(request, tmp_path):
+    if request.param == "json":
+        return create_state_from_source(f"json:{tmp_path}")
     return create_state_from_source(f"sqlite:{tmp_path / 'test.db'}")
 
 

--- a/tests/test_web_login_tokens.py
+++ b/tests/test_web_login_tokens.py
@@ -9,8 +9,10 @@ import pytest
 from initbot_core.state.factory import create_state_from_source
 
 
-@pytest.fixture(name="token_state")
-def _token_state(tmp_path):
+@pytest.fixture(params=["json", "sqlite"], name="token_state")
+def _token_state(request, tmp_path):
+    if request.param == "json":
+        return create_state_from_source(f"json:{tmp_path}")
     return create_state_from_source(f"sqlite:{tmp_path / 'test.db'}")
 
 

--- a/tools/test/docker_web.sh
+++ b/tools/test/docker_web.sh
@@ -6,6 +6,6 @@
 
 set -ue
 
-output=$(docker run --rm initbot-web 2>&1) || true
+output=$(docker run --rm -e STATE=unknown:foo initbot-web 2>&1) || true
 echo "$output"
-echo "$output" | grep -qF "initbot-web requires a SQLite state URI"
+echo "$output" | grep -qF "Unknown kind of data store: unknown"


### PR DESCRIPTION
## Summary

- Implements `import_from()` on `LocalCharacterState`, `LocalPlayerState`, and `LocalCharacterActionState`
- Replaces `NotImplementedError` stubs in `_LocalWebLoginTokenState` with a file-backed implementation (`web_login_tokens.json`), matching the SQL backend's 60s TTL and single-use enforcement
- Replaces `NotImplementedError` stubs in `_LocalSessionSecretState` with a file-backed implementation (`session_secret.json`)
- Moves `_WEB_LOGIN_TOKEN_TTL` to `state.py` alongside `_SESSION_SECRET_TTL` so both backends share one definition
- Removes the SQLite-only guard from `app.py` — the factory already raises a clear `ValueError` for unknown state types
- Parametrizes `test_web_login_tokens` and `test_session_secret` fixtures over both `json` and `sqlite` backends
- Updates the web Docker smoke test to verify the factory's error for unknown state types

## Test plan

- All 49 tests in `test_web_login_tokens`, `test_session_secret`, `test_state_persistence`, and `test_player_state` pass for both `json` and `sqlite` backends
- CI passes on all Python versions (3.10–3.14) and Docker smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)