### PR TITLE
Replace NerdDiceRoll with DiceExpression supporting compound and repeat specs

### DIFF
--- a/packages/initbot-chat/src/initbot_chat/commands/character.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/character.py
@@ -15,7 +15,7 @@ from initbot_core.data.character import (
     CharacterData,
     is_eligible_for_pruning,
 )
-from initbot_core.models.roll import NerdDiceRoll
+from initbot_core.models.roll import DiceExpression
 from initbot_core.state.state import State
 
 
@@ -54,7 +54,7 @@ async def init_dice(ctx: commands.Context, *args: str) -> None:
     name = tokens[:-1]
 
     try:
-        NerdDiceRoll.create(spec)
+        DiceExpression.create(spec)
     except ValueError as exc:
         raise ValueError(
             f"'{spec}' is not a valid dice spec. Use a format like d20, d20+3, or 2d6-1."

--- a/packages/initbot-chat/src/initbot_chat/commands/init.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/init.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 from initbot_chat.commands.character import CharacterData, characters
 from initbot_chat.commands.utils import player_name, sync_player
-from initbot_core.models.roll import NerdDiceRoll
+from initbot_core.models.roll import DiceExpression
 from initbot_core.utils import is_int
 
 
@@ -56,7 +56,7 @@ async def init(ctx: commands.Context, *args: str) -> None:
     )
     if initiative is None:
         if cdi.initiative_dice is not None:
-            initiative = NerdDiceRoll.create(cdi.initiative_dice).roll_one()
+            initiative = DiceExpression.create(cdi.initiative_dice).roll_one()
         else:
             raise ValueError(
                 f"No initiative dice set for {cdi.name}. Use `$init_dice {cdi.name} d20+3` first."

--- a/packages/initbot-chat/src/initbot_chat/commands/roll.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/roll.py
@@ -16,8 +16,10 @@ async def roll(ctx: commands.Context, *words: str) -> None:
     The *dice* to roll can be, for example, d20, 2d6, or d8+2.
     This follows the usual notation [dice]d{sides}[+/-mod] to say what kind of die to roll (how many sides), how many of those to roll, and how much bonus to add (or subtract).
 
-    To make the same roll several times in a row and get each result separately, add [rolls]x, so for example, 3x1d6+1.
-    This generates a reply with a total and the individual rolls, for example, 14 (5, 7, 2).
+    You can combine different dice types with + or -: d20+d8 rolls both and adds them, d20+d8+d6 rolls all three, and 2d6+d4+3 rolls the mixed group and adds 3.
+
+    To evaluate an expression several times and see each result separately, add [rolls]x: 3xd6 rolls d6 three times, and 2x(d20+d8) evaluates d20+d8 twice.
+    This generates a reply showing each result and the total, for example, 4+13=17.
 
     The bot just replaces anything that looks like a dice roll in your message with the result of the roll.
     For example, "roll d20+5 to attack the construct for 1d6+3 damage" will generate a reply like "Mediocre Mel rolled 15 to attack the construct for 7 damage".

--- a/packages/initbot-core/src/initbot_core/models/roll.py
+++ b/packages/initbot-core/src/initbot_core/models/roll.py
@@ -5,15 +5,19 @@
 import random
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence, Set
+from collections.abc import Iterable, Set
 from dataclasses import dataclass
 from typing import Final
 
 _CRITICAL_FAILURE_EMOJIS: Final = ("😭", "😱", "💩", "🚽", "💔")
 
-_NERD_DICE_ROLL_PATTERN = re.compile(
-    r"^(([0-9]+)x)?([0-9]*)d([0-9]+)([+-][0-9]+)?$", re.IGNORECASE
-)
+_DIE_TERM_PATTERN: Final = re.compile(r"^([0-9]*)d([0-9]+)$", re.IGNORECASE)
+_REPEAT_PREFIX_PATTERN: Final = re.compile(r"^([0-9]+)x(.+)$", re.IGNORECASE)
+
+# Characters stripped from word boundaries when scanning prose for dice specs.
+# Parentheses are intentionally excluded: they are part of the Nx(expr) syntax
+# and must not be stripped before the spec reaches DiceExpression.create().
+_PROSE_STRIP_CHARS: Final = ".,!?;:[]{}\"'-"
 
 
 def render_dice_rolls(words: Iterable[str]) -> str:
@@ -44,12 +48,12 @@ def render_dice_rolls_in_text(text: str) -> str:
     result_words = []
 
     for word in words:
-        clean_word = word.strip(".,!?;:()[]{}\"'-")
+        clean_word = word.strip(_PROSE_STRIP_CHARS)
         rendered_word, was_dice = _try_to_detect_and_render_dice_roll(clean_word, text)
 
         if was_dice:
-            prefix = word[: len(word) - len(word.lstrip(".,!?;:()[]{}\"'-"))]
-            suffix = word[len(word.rstrip(".,!?;:()[]{}\"'-")) :]
+            prefix = word[: len(word) - len(word.lstrip(_PROSE_STRIP_CHARS))]
+            suffix = word[len(word.rstrip(_PROSE_STRIP_CHARS)) :]
             result_words.append(prefix + rendered_word + suffix)
         else:
             result_words.append(word)
@@ -60,7 +64,7 @@ def render_dice_rolls_in_text(text: str) -> str:
 def contains_dice_rolls(text: str) -> bool:
     words = text.split()
     for word in words:
-        clean_word = word.strip(".,!?;:()[]{}\"'-")
+        clean_word = word.strip(_PROSE_STRIP_CHARS)
         _, was_dice = _try_to_detect_and_render_dice_roll(clean_word, text)
         if was_dice:
             return True
@@ -94,85 +98,164 @@ class _DiceRoll(ABC):
         pass
 
 
-class IntDiceRoll(_DiceRoll, ABC):
-    def roll(self) -> str:
-        rolls = self.roll_all()
-        if len(rolls) == 1:
-            return str(rolls[0])
-        return f"{sum(rolls)} ({str(rolls).strip('[]')})"
+@dataclass(frozen=True)
+class _DieTerm:
+    sides: int
+    count: int = 1
 
-    @abstractmethod
-    def roll_all(self) -> Sequence[int]:
-        pass
+    def roll(self) -> int:
+        return sum(random.randint(1, self.sides) for _ in range(self.count))
 
-    @abstractmethod
-    def roll_one(self) -> int:
-        pass
+    @property
+    def min_value(self) -> int:
+        return self.count
+
+    @property
+    def max_value(self) -> int:
+        return self.count * self.sides
+
+
+def _parse_die_term(token: str) -> _DieTerm:
+    """Parse a token like 'd6', '2d6', 'd20' into a _DieTerm. Raises ValueError on failure."""
+    match = _DIE_TERM_PATTERN.match(token)
+    if not match:
+        raise ValueError(f"'{token}' is not a valid die term")
+    count = int(match.group(1)) if match.group(1) else 1
+    sides = int(match.group(2))
+    return _DieTerm(sides=sides, count=count)
+
+
+def _tokenise(expr: str) -> list[tuple[int, str]]:
+    """Split a dice expression into signed tokens.
+
+    Returns a list of (sign, token) pairs where sign is +1 or -1.
+    Example: 'd20+d8-3' → [(+1,'d20'), (+1,'d8'), (-1,'3')]
+    """
+    tokens: list[tuple[int, str]] = []
+    current = ""
+    sign = 1
+    for ch in expr:
+        if ch in ("+", "-") and current:
+            tokens.append((sign, current))
+            current = ""
+            sign = 1 if ch == "+" else -1
+        else:
+            current += ch
+    if current:
+        tokens.append((sign, current))
+    return tokens
 
 
 @dataclass(frozen=True)
-class NerdDiceRoll(IntDiceRoll):
-    sides: int
-    dice: int = 1
-    modifier: int = 0
-    rolls: int = 1
+class DiceExpression(_DiceRoll):
+    """A dice expression with one or more signed terms and an optional repeat count.
 
-    def roll_all(self) -> Sequence[int]:
-        return tuple(self.roll_one() for _ in range(0, self.rolls))
+    Supports specs like: d6, 2d6, d20+5, d20+d8+d6, 2xd20, 2x(d20+d8-3).
+    """
+
+    terms: tuple[tuple[int, "_DieTerm | int"], ...]
+    repeat: int = 1
 
     def roll_one(self) -> int:
-        return (
-            sum(random.randint(1, self.sides) for _ in range(0, self.dice))
-            + self.modifier
+        """Roll the expression once and return the integer total."""
+        return sum(
+            sign * (term.roll() if isinstance(term, _DieTerm) else term)
+            for sign, term in self.terms
         )
 
-    def __str__(self) -> str:
-        result = ""
-        if self.rolls != 1:
-            result += f"{self.rolls}x"
-        if self.dice != 1:
-            result += str(self.dice)
-        result += f"d{self.sides}"
-        if self.modifier != 0:
-            if self.modifier > 0:
-                result += "+"
-            result += str(self.modifier)
-        return result
+    def _is_single_die(self) -> bool:
+        """True when the expression has exactly one die term with count=1 (constants allowed)."""
+        die_terms = [(s, t) for s, t in self.terms if isinstance(t, _DieTerm)]
+        return len(die_terms) == 1 and die_terms[0][1].count == 1
 
-    def _format_die_value(self, value: int) -> str:
-        if self.dice == 1:
-            if value == self.dice + self.modifier:
+    def _expression_min(self) -> int:
+        return sum(
+            s * (t.min_value if isinstance(t, _DieTerm) else t) for s, t in self.terms
+        )
+
+    def _expression_max(self) -> int:
+        return sum(
+            s * (t.max_value if isinstance(t, _DieTerm) else t) for s, t in self.terms
+        )
+
+    def _format_single(self, value: int) -> str:
+        if self._is_single_die():
+            if value == self._expression_min():
                 return f"**{value}** {random.choice(_CRITICAL_FAILURE_EMOJIS)}"
-            if value == self.dice * self.sides + self.modifier:
+            if value == self._expression_max():
                 return f"**{value}** \U0001f3af"
         return str(value)
 
     def roll(self) -> str:
-        rolls = self.roll_all()
-        if self.rolls == 1:
-            if self.dice == 1:
-                return self._format_die_value(rolls[0])
-            return (
-                str(rolls[0])
-                if len(rolls) == 1
-                else f"{sum(rolls)} ({str(list(rolls)).strip('[]')})"
-            )
-        formatted = [self._format_die_value(r) for r in rolls]
-        return f"{sum(rolls)} ({', '.join(formatted)})"
+        if self.repeat == 1:
+            return self._format_single(self.roll_one())
+        raw = [self.roll_one() for _ in range(self.repeat)]
+        parts = [self._format_single(v) for v in raw]
+        return "+".join(parts) + f"={sum(raw)}"
+
+    def __str__(self) -> str:
+        parts = []
+        for i, (sign, term) in enumerate(self.terms):
+            prefix = ("" if sign == 1 else "-") if i == 0 else "+" if sign == 1 else "-"
+            if isinstance(term, _DieTerm):
+                die_str = (
+                    f"{term.count}d{term.sides}"
+                    if term.count != 1
+                    else f"d{term.sides}"
+                )
+                parts.append(prefix + die_str)
+            else:
+                parts.append(prefix + str(term))
+        expr = "".join(parts)
+        if self.repeat == 1:
+            return expr
+        needs_parens = len(self.terms) > 1 or (
+            len(self.terms) == 1 and isinstance(self.terms[0][1], int)
+        )
+        inner = f"({expr})" if needs_parens else expr
+        return f"{self.repeat}x{inner}"
 
     @staticmethod
-    def create(spec: str) -> "NerdDiceRoll":
-        match = _NERD_DICE_ROLL_PATTERN.match(spec)
-        if match:
-            args = {"sides": int(match.group(4))}
-            if match.group(3):
-                args["dice"] = int(match.group(3))
-            if match.group(5):
-                args["modifier"] = int(match.group(5))
-            if match.group(2):
-                args["rolls"] = int(match.group(2))
-            return NerdDiceRoll(**args)
-        raise ValueError(f"'{spec}' is not supported")
+    def create(spec: str) -> "DiceExpression":
+        """Parse a dice spec string into a DiceExpression. Raises ValueError on failure."""
+        repeat = 1
+        remainder = spec
+
+        repeat_match = _REPEAT_PREFIX_PATTERN.match(spec)
+        if repeat_match:
+            repeat = int(repeat_match.group(1))
+            remainder = repeat_match.group(2)
+
+        if remainder.startswith("("):
+            remainder = remainder[1:]
+            if remainder.endswith(")"):
+                remainder = remainder[:-1]
+
+        raw_tokens = _tokenise(remainder)
+        if not raw_tokens:
+            raise ValueError(f"'{spec}' is not a valid dice expression")
+
+        terms: list[tuple[int, _DieTerm | int]] = []
+        has_die = False
+        for sign, token in raw_tokens:
+            try:
+                die = _parse_die_term(token)
+                terms.append((sign, die))
+                has_die = True
+            except ValueError:
+                try:
+                    terms.append((sign, int(token)))
+                except ValueError as exc:
+                    raise ValueError(
+                        f"'{token}' in '{spec}' is not a valid die term or integer"
+                    ) from exc
+
+        if not has_die:
+            raise ValueError(
+                f"'{spec}' contains no dice — use a die spec like d6 or 2d20"
+            )
+
+        return DiceExpression(terms=tuple(terms), repeat=repeat)
 
 
-_DICE_ROLL_CLASSES: Set[type[_DiceRoll]] = frozenset((NerdDiceRoll,))
+_DICE_ROLL_CLASSES: Set[type[_DiceRoll]] = frozenset((DiceExpression,))

--- a/plans/ideas.md
+++ b/plans/ideas.md
@@ -12,7 +12,6 @@
 
 ## chat
 
-- support d20+d8+d6
 - support advantage / don't total 2xd20
 - relax command parsing
 - protect discord.py token

--- a/tests/test_models_roll.py
+++ b/tests/test_models_roll.py
@@ -7,73 +7,174 @@ import re
 import unittest
 from unittest.mock import patch
 
-from initbot_core.models.roll import NerdDiceRoll, render_dice_rolls
+import pytest
+
+from initbot_core.models.roll import (
+    DiceExpression,
+    render_dice_rolls,
+    render_dice_rolls_in_text,
+)
 
 
-class TestModelsRolls(unittest.TestCase):
+class TestRenderDiceRolls(unittest.TestCase):
     def test_render_dice_rolls(self):
         s = "d20+5 to attack the construct for 1d6+3 damage"
         result = render_dice_rolls(s.split())
-        print(result)
         # Result may contain bold/emoji for natural min/max, so allow optional formatting
         assert re.match(
             r"^(\*\*\d+\*\* .|\d+) to attack the construct for (\*\*\d+\*\* .|\d+) damage$",
             result,
         )
 
+    def test_render_dice_rolls_in_text_repeat_compound_no_trailing_paren(self):
+        # "1x(d20)" in plain chat must not produce a trailing ) in the output.
+        # repeat=1 rolls once and returns a plain number (no v1+...=total format).
+        result = render_dice_rolls_in_text("roll 1x(d20) for initiative")
+        assert ")" not in result
+        assert re.search(r"roll (\*\*\d+\*\* .|\d+) for initiative", result)
 
-class TestNerdDiceRollHighlighting(unittest.TestCase):
+
+class TestDiceExpressionHighlighting(unittest.TestCase):
     def test_single_die_natural_min(self):
-        roll = NerdDiceRoll(sides=6)
+        expr = DiceExpression.create("d6")
         with patch("random.randint", return_value=1):
-            result = roll.roll()
+            result = expr.roll()
             assert re.match(r"^\*\*1\*\* .$", result)
 
     def test_single_die_natural_max(self):
-        roll = NerdDiceRoll(sides=6)
+        expr = DiceExpression.create("d6")
         with patch("random.randint", return_value=6):
-            assert roll.roll() == "**6** \U0001f3af"
+            assert expr.roll() == "**6** \U0001f3af"
 
     def test_single_die_ordinary(self):
-        roll = NerdDiceRoll(sides=6)
+        expr = DiceExpression.create("d6")
         with patch("random.randint", return_value=3):
-            assert roll.roll() == "3"
+            assert expr.roll() == "3"
 
     def test_single_die_with_modifier_natural_min(self):
-        roll = NerdDiceRoll(sides=20, modifier=5)
+        expr = DiceExpression.create("d20+5")
         with patch("random.randint", return_value=1):
-            result = roll.roll()
+            result = expr.roll()
             assert re.match(r"^\*\*6\*\* .$", result)
 
     def test_single_die_with_modifier_natural_max(self):
-        roll = NerdDiceRoll(sides=20, modifier=5)
+        expr = DiceExpression.create("d20+5")
         with patch("random.randint", return_value=20):
-            assert roll.roll() == "**25** \U0001f3af"
+            assert expr.roll() == "**25** \U0001f3af"
 
     def test_multiple_dice_no_highlight(self):
-        roll = NerdDiceRoll(sides=6, dice=2)
+        expr = DiceExpression.create("2d6")
         with patch("random.randint", return_value=1):
-            # All ones — but not highlighted for multi-die rolls
-            assert roll.roll() == "2"
+            assert expr.roll() == "2"
 
-    def test_multiple_dice_no_highlight_with_breakdown(self):
-        roll = NerdDiceRoll(sides=6, dice=2, rolls=1)
-        # Both dice return 1 — no highlighting expected
+    def test_compound_no_highlight(self):
+        expr = DiceExpression.create("d20+d8")
         with patch("random.randint", return_value=1):
-            result = roll.roll()
-            assert "**" not in result
+            assert expr.roll() == "2"
+            assert "**" not in expr.roll()
 
     def test_multi_roll_single_die_highlights_individuals(self):
-        roll = NerdDiceRoll(sides=6, rolls=3)
-        # Returns 1, 6, 3 in sequence
+        expr = DiceExpression.create("3xd6")
         with patch("random.randint", side_effect=[1, 6, 3]):
-            result = roll.roll()
+            result = expr.roll()
         assert re.search(r"\*\*1\*\* .", result)
         assert "**6** \U0001f3af" in result
-        assert result.startswith("10 (")
+        assert result.endswith("=10")
 
     def test_multi_roll_multiple_dice_no_highlight(self):
-        roll = NerdDiceRoll(sides=6, dice=2, rolls=3)
+        expr = DiceExpression.create("3x2d6")
         with patch("random.randint", return_value=1):
-            result = roll.roll()
+            result = expr.roll()
         assert "**" not in result
+
+
+class TestDiceExpressionCompound(unittest.TestCase):
+    def test_two_die_terms(self):
+        expr = DiceExpression.create("d20+d8")
+        value = expr.roll_one()
+        assert isinstance(value, int)
+        assert 2 <= value <= 28
+
+    def test_three_die_terms(self):
+        expr = DiceExpression.create("d20+d8+d6")
+        value = expr.roll_one()
+        assert isinstance(value, int)
+        assert 3 <= value <= 44
+
+    def test_mixed_dice_and_constant(self):
+        expr = DiceExpression.create("2d6+d4+3")
+        value = expr.roll_one()
+        assert isinstance(value, int)
+        assert 6 <= value <= 18
+
+    def test_subtraction(self):
+        expr = DiceExpression.create("d20-d6")
+        value = expr.roll_one()
+        assert isinstance(value, int)
+        assert -5 <= value <= 19
+
+    def test_roll_one_returns_int(self):
+        expr = DiceExpression.create("d20+d8+3")
+        result = expr.roll_one()
+        assert isinstance(result, int)
+
+    def test_single_roll_no_equals(self):
+        expr = DiceExpression.create("d20+d8")
+        result = expr.roll()
+        assert "=" not in result
+
+
+class TestDiceExpressionRepeat(unittest.TestCase):
+    def test_two_x_single_die_format(self):
+        expr = DiceExpression.create("2xd20")
+        result = expr.roll()
+        assert re.match(r"^(\*\*\d+\*\* .|\d+)\+(\*\*\d+\*\* .|\d+)=\d+$", result)
+
+    def test_two_x_compound_format(self):
+        expr = DiceExpression.create("2x(d20-d3+5)")
+        result = expr.roll()
+        assert re.match(r"^\d+\+\d+=\d+$", result)
+
+    def test_three_x_mocked_values(self):
+        expr = DiceExpression.create("3xd6")
+        with patch("random.randint", side_effect=[1, 6, 3]):
+            result = expr.roll()
+        assert re.search(r"\*\*1\*\* .", result)
+        assert "**6** \U0001f3af" in result
+        assert result.endswith("=10")
+
+    def test_repeat_total_is_correct(self):
+        expr = DiceExpression.create("2xd6")
+        with patch("random.randint", side_effect=[4, 3]):
+            result = expr.roll()
+        assert result == "4+3=7"
+
+    def test_repeat_compound_total_is_correct(self):
+        expr = DiceExpression.create("2x(d6+d4)")
+        with patch("random.randint", side_effect=[5, 3, 2, 4]):
+            result = expr.roll()
+        assert result == "8+6=14"
+
+    def test_repeat_with_unmatched_open_paren(self):
+        # create() tolerates a leading ( without a matching ) e.g. from callers
+        # that strip trailing punctuation before parsing
+        expr = DiceExpression.create("2x(d6")
+        with patch("random.randint", side_effect=[5, 2]):
+            result = expr.roll()
+        assert result == "5+2=7"
+
+
+class TestDiceExpressionCreate(unittest.TestCase):
+    def test_invalid_spec_raises(self):
+        with pytest.raises(ValueError, match="notadice"):
+            DiceExpression.create("notadice")
+
+    def test_plain_integer_raises(self):
+        with pytest.raises(ValueError, match="no dice"):
+            DiceExpression.create("5")
+
+    def test_is_valid_spec_true(self):
+        assert DiceExpression.is_valid_spec("d20+d8")
+
+    def test_is_valid_spec_false(self):
+        assert not DiceExpression.is_valid_spec("hello")


### PR DESCRIPTION
## Summary

- Replaces `NerdDiceRoll` with `DiceExpression`, which handles all existing specs (`d6`, `2d6`, `d20+5`, `3xd6`) plus new ones
- Compound expressions: `d20+d8+d6`, `2d6+d4+3`, `d20-d6`
- Repeated compound rolls: `2x(d20+d8)` → `8+15=23`; repeat output format is now `v1+v2+...=total` (was `total (v1, v2, ...)`)
- `NerdDiceRoll` removed from public API; call sites in `character.py` and `init.py` updated to `DiceExpression`
- Parentheses excluded from prose strip-chars so `Nx(expr)` tokens in plain chat messages reach `create()` intact

## Test plan

- [ ] `pytest -q` passes (240 tests)
- [ ] `$roll d20+d8+d6 to hit` returns a single summed result
- [ ] `$roll 2x(d20+d8)` returns `v1+v2=total` format
- [ ] Plain chat message `2x(d20+d8)` resolves without trailing `)`
- [ ] Initiative rolling (`$init`) still works with stored dice specs