### PR TITLE
Fix incorrect max bounds in DiceExpression range tests

### DIFF
--- a/plans/ideas.md
+++ b/plans/ideas.md
@@ -1,6 +1,7 @@
 # Ideas
 
 - Does sqlite support listening for events?
+- Use hypothesis for property-based tests on DiceExpression: verify roll results always fall within the computed min/max without hand-calculating bounds
 - claude's /security-review seems to be testing for a whole bunch of typical web vulnerabilities; would be great to have these in CI
 - consider a dev container
 - rename LocalState store to JsonState store or similar, update URI as well

--- a/tests/test_models_roll.py
+++ b/tests/test_models_roll.py
@@ -99,13 +99,13 @@ class TestDiceExpressionCompound(unittest.TestCase):
         expr = DiceExpression.create("d20+d8+d6")
         value = expr.roll_one()
         assert isinstance(value, int)
-        assert 3 <= value <= 44
+        assert 3 <= value <= 34
 
     def test_mixed_dice_and_constant(self):
         expr = DiceExpression.create("2d6+d4+3")
         value = expr.roll_one()
         assert isinstance(value, int)
-        assert 6 <= value <= 18
+        assert 6 <= value <= 19
 
     def test_subtraction(self):
         expr = DiceExpression.create("d20-d6")


### PR DESCRIPTION
## Summary

- `d20+d8+d6` max is 20+8+6=34, not 44
- `2d6+d4+3` max is 12+4+3=19, not 18

## Test plan

- [ ] CI passes on main after merge