### PR TITLE
Add initiative editing to web tracker

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "sse",
+      "url": "http://localhost:8931/sse"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,27 @@ The web app package is at `packages/initbot-web/`. The single current page is th
 - **Playwright MCP** is configured and connected. Use it to navigate to the running app, take screenshots, and verify visual changes after editing templates.
 - **`/frontend-design` skill** is installed. Invoke it at the start of design work to establish a visual direction before writing code.
 
+#### Playwright setup
+
+**Without a sandbox:** Enable the official plugin in `~/.claude/settings.json`:
+```json
+"enabledPlugins": {
+  "playwright@claude-plugins-official": true
+}
+```
+The plugin starts the browser automatically — no other configuration needed. The `.mcp.json` in the project root is not required and can be ignored.
+
+#### Playwright in a nono sandbox
+
+Browsers cannot launch inside a nono sandbox (macOS Seatbelt blocks the Mach IPC and xattr syscalls browsers require). The workaround is to run the Playwright MCP server as an external process and connect to it over localhost.
+
+**Before starting Claude Code in nono**, run in a separate terminal:
+```
+tools/run_playwright.sh
+```
+
+This starts `@playwright/mcp` on `http://localhost:8931/sse`. Claude Code connects to it via SSE transport (configured in `~/.claude/mcp.json`), so all browser automation runs outside the sandbox entirely. The nono profile needs no extra `--allow` flags beyond the defaults.
+
 ### Dev server
 
 Start with:
@@ -42,19 +63,49 @@ Start with:
 tools/run_web_dev.sh
 ```
 
-This generates 5 sample characters with fresh initiative timestamps, exports them to `dev-state/dev.sqlite`, and starts the server at:
+This generates 5 sample characters with fresh initiative timestamps, exports them to `dev-state/dev.sqlite`, and starts the server. The server prints the session URL to stdout:
 ```
-http://localhost:8080/s/dev/
+URL: http://localhost:8080/dev/<token>/
 ```
 
-The state is regenerated on each run (timestamps stay fresh). `dev-state/` is gitignored.
+Read the URL from the server output (e.g. `/tmp/initbot-web-dev.log` if started in the background). The state is regenerated on each run (timestamps stay fresh). `dev-state/` is gitignored.
+
+### Datastar RC.8 gotchas
+
+The tracker uses Datastar v1.0.0-RC.8. Several things differ from what documentation or LLM training data might suggest:
+
+**Attribute format — colons, not hyphens, for sub-keys:**
+- `data-on:click="expr"` ✓  — `data-on-click` is silently ignored
+- `data-on:submit__prevent="@post(...)"` ✓
+- `data-on:keydown__escape="expr"` ✗  — fires on **every** keydown, not just Escape; use `data-on:keydown="evt.key==='Escape' && expr"` instead
+- `data-bind:signalname` ✓
+- Plugins with no sub-key (`data-show`, `data-signals`, `data-init`, `data-text`, `data-effect`) still use plain hyphens ✓
+
+**`data-on:click` and `data-init` cannot coexist on the same element.** Put `data-on:click` on a separate child div used as an event-delegation wrapper; `data-init` stays on the outer div.
+
+**HTML lowercases attribute keys — signal names must be all-lowercase when referenced via `data-bind:`.** `data-bind:initVal` becomes `data-bind:initval` in the DOM. The bind plugin then looks for signal `initval`, not `initVal`. Keep signal names that appear in `data-bind:` all-lowercase throughout (`data-signals`, expressions, and server-side JSON keys must all agree).
+
+**`evt` is available in `data-on:*` expressions.** The `on` plugin injects `evt` as an extra named argument so `evt.target.closest(...)` works correctly.
+
+**Server → client signal reset:** After a POST action, return `SSE.patch_signals({"editing": False})` to dismiss the edit panel. Dispatching `datastar-signal-patch` CustomEvents from the browser externally has no effect.
 
 ### Design iteration workflow
 
-1. Start the dev server (`tools/run_web_dev.sh`)
-2. Use Playwright MCP to navigate to `http://localhost:8080/s/dev/` and take a screenshot
-3. Edit `packages/initbot-web/src/initbot_web/templates/tracker.html`
-4. Use Playwright MCP to verify the result visually before committing
+1. Start the dev server in the background: `tools/run_web_dev.sh &>/tmp/initbot-web-dev.log &`
+2. Read the URL from the log: `grep '^URL:' /tmp/initbot-web-dev.log`
+3. Use Playwright MCP to navigate to that URL and take a screenshot
+4. Edit `packages/initbot-web/src/initbot_web/templates/tracker.html`
+5. Use Playwright MCP to verify the result visually before committing
+
+**The dev server does not auto-reload.** After changing Python source files (routes, handlers), kill the running server and restart it. Stale code returns wrong HTTP status codes with no helpful error — always restart after backend changes.
+
+**To inspect what Datastar sends in a `@post()`, intercept `window.fetch` before triggering the action:**
+```js
+window._bodies = [];
+const orig = window.fetch;
+window.fetch = async (url, opts) => { window._bodies.push(opts?.body); return orig(url, opts); };
+```
+Then check `window._bodies` in a follow-up `browser_evaluate`. Server logs show status codes only, not bodies.
 
 ## Implementation Workflow
 

--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -49,7 +49,7 @@ def _write_session(
     request.session["expires_at"] = int(time.time()) + SESSION_TTL
 
 
-def make_routes(
+def make_routes(  # pylint: disable=too-many-locals,too-many-statements
     state: State,
     templates: Jinja2Templates,
     url_path_prefix: str,
@@ -58,6 +58,7 @@ def make_routes(
 ) -> list[Mount]:
     tracker_url = f"/{url_path_prefix}/tracker/"
     sse_url = f"/{url_path_prefix}/tracker/sse"
+    set_initiative_url = f"/{url_path_prefix}/tracker/set-initiative"
 
     async def login_page(request: Request) -> Response:
         """GET: validate token without consuming it; render auto-submit login form.
@@ -114,6 +115,7 @@ def make_routes(
             {
                 "player_name": player_name,
                 "sse_url": sse_url,
+                "set_initiative_url": set_initiative_url,
                 "has_high_severity_vulnerabilities": vuln_state.has_high_severity_vulnerabilities,
             },
         )
@@ -167,6 +169,29 @@ def make_routes(
             return err
         return await _tracker_sse(request)
 
+    @datastar_response
+    async def _set_initiative(
+        request: Request,
+    ) -> DatastarEvent | tuple[()]:
+        data = await request.json()
+        char_name: str = data.get("editchar", "")
+        try:
+            initiative = int(data.get("initval", ""))
+            if initiative < -99 or initiative > 99:
+                return ()
+            char = state.characters.get_from_name(char_name)
+        except (TypeError, ValueError, KeyError):
+            return ()
+        char.initiative = initiative
+        char.last_used = int(time.time())
+        state.characters.update_and_store(char)
+        return SSE.patch_signals({"editing": False})
+
+    async def set_initiative(request: Request) -> Response:
+        if (err := _require_auth(request)) is not None:
+            return err
+        return await _set_initiative(request)
+
     async def logout(request: Request) -> Response:
         request.session.clear()
         return Response(status_code=200)
@@ -177,6 +202,7 @@ def make_routes(
             routes=[
                 Route("/tracker/", tracker_page),
                 Route("/tracker/sse", tracker_sse),
+                Route("/tracker/set-initiative", set_initiative, methods=["POST"]),
                 Route("/logout", logout),
                 Route("/{token}/", login_page, methods=["GET"]),
                 Route("/{token}/", login_post, methods=["POST"]),
@@ -198,10 +224,22 @@ def _render_alert(has_high_severity_vulnerabilities: bool) -> str:
     return f'<div id="security-alert">{content}</div>'
 
 
+def _render_edit_button(char_name: str) -> str:
+    safe = _safe_str(char_name)
+    return (
+        f'<button type="button" class="edit-btn" data-char="{safe}">\U0001f58a</button>'
+    )
+
+
 def _render_rows(chars_with_names: list[tuple[CharacterData, str]]) -> str:
     rows = "".join(
-        f'<tr id="r{i}"><td>{i + 1}</td><td>{_safe_int(c.initiative)}</td>'
-        f"<td>{_safe_str(c.name)}</td><td>{_safe_str(name)}</td></tr>"
+        f'<tr id="r{i}">'
+        f"<td>{i + 1}</td>"
+        f'<td><span class="init-val">{_safe_int(c.initiative)}</span>'
+        f" {_render_edit_button(c.name)}</td>"
+        f"<td>{_safe_str(c.name)}</td>"
+        f"<td>{_safe_str(name)}</td>"
+        f"</tr>"
         for i, (c, name) in enumerate(chars_with_names)
     )
     return f'<tbody id="initiative-rows">{rows}</tbody>'
@@ -209,7 +247,11 @@ def _render_rows(chars_with_names: list[tuple[CharacterData, str]]) -> str:
 
 def _render_idle_rows(chars_with_names: list[tuple[CharacterData, str]]) -> str:
     rows = "".join(
-        f"<tr><td>{_safe_str(c.name)}</td><td>{_safe_str(name)}</td></tr>"
+        f"<tr>"
+        f"<td>{_render_edit_button(c.name)}</td>"
+        f"<td>{_safe_str(c.name)}</td>"
+        f"<td>{_safe_str(name)}</td>"
+        f"</tr>"
         for c, name in chars_with_names
     )
     return f'<tbody id="idle-rows">{rows}</tbody>'

--- a/packages/initbot-web/src/initbot_web/templates/tracker.html
+++ b/packages/initbot-web/src/initbot_web/templates/tracker.html
@@ -171,14 +171,92 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       letter-spacing: 0.08em;
     }
 
+    /* ── Edit panel ───────────────────────────────────────────── */
+    #edit-panel {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+      padding: 0.6rem 1rem;
+      border-left: 4px solid var(--color-gold);
+      background: var(--color-row-alt);
+    }
+
+    #edit-label {
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--color-gold);
+      min-width: 6rem;
+    }
+
+    #edit-panel form {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    #edit-input {
+      width: 5rem;
+      font-family: var(--font-main);
+      font-size: 1rem;
+      color: var(--color-gold);
+      background: transparent;
+      border: none;
+      border-bottom: 2px solid var(--color-gold);
+      padding: 0.15rem 0.25rem;
+      text-align: center;
+      outline: none;
+    }
+
+    /* ── Edit button ──────────────────────────────────────────── */
+    .edit-btn {
+      background: none;
+      border: none;
+      padding: 0 0.25rem;
+      color: var(--color-gold);
+      opacity: 0.45;
+      cursor: pointer;
+      font-size: 0.85rem;
+      line-height: 1;
+    }
+
+    .edit-btn:hover {
+      opacity: 1;
+    }
+
+    /* ── Touch cancel button (hidden on pointer devices) ─────── */
+    .cancel-touch {
+      display: none;
+      background: none;
+      border: 1px solid var(--color-offset);
+      font-size: 0.85rem;
+      padding: 0.15rem 0.4rem;
+      cursor: pointer;
+      color: var(--color-ink);
+      font-family: var(--font-main);
+    }
+
+    @media (hover: none) {
+      .cancel-touch {
+        display: inline;
+      }
+    }
+
     /* ── Idle Characters section ──────────────────────────────── */
     .idle-section {
       margin-top: 2.5rem;
       opacity: 0.5;
     }
 
-    /* Character name — bold (mirrors initiative table's 3rd column) */
+    /* Init column — edit button cell */
     .idle-section tbody td:first-child {
+      text-align: center;
+      width: 3rem;
+    }
+
+    /* Character name — bold (mirrors initiative table's 3rd column) */
+    .idle-section tbody td:nth-child(2) {
       font-weight: 700;
       text-align: left;
       color: var(--color-ink);
@@ -186,7 +264,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     }
 
     /* Player name — muted (mirrors initiative table's 4th column) */
-    .idle-section tbody td:nth-child(2) {
+    .idle-section tbody td:nth-child(3) {
       font-weight: 400;
       font-size: 0.9rem;
       color: rgba(26, 18, 9, 0.65);
@@ -223,24 +301,38 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   {% if player_name %}<div id="player-bar">{{ player_name }}</div>{% endif %}
   <div id="security-alert">{% if has_high_severity_vulnerabilities %}<p>This application needs to receive a security update.</p>{% endif %}</div>
   <h1>Initiative Order</h1>
-  <div data-init="@get('{{ sse_url }}')">
-    <table>
-      <thead>
-        <tr><th>#</th><th>Init</th><th>Character</th><th>Player</th></tr>
-      </thead>
-      <tbody id="initiative-rows">
-        <tr><td colspan="4">Alea nondum iacta est…</td></tr>
-      </tbody>
-    </table>
-    <section class="idle-section">
-      <h2>Idle Characters</h2>
+  <div data-init="@get('{{ sse_url }}')"
+       data-signals='{"editing": false, "editchar": "", "initval": ""}'>
+    <div id="edit-panel" data-show="$editing" style="display: none">
+      <span id="edit-label" data-text="$editchar"></span>
+      <form data-on:submit__prevent="@post('{{ set_initiative_url }}')"
+            data-effect="$editing && setTimeout(() => document.getElementById('edit-input')?.focus(), 0)">
+        <input id="edit-input" type="number" data-bind:initval
+               min="-99" max="99" autocomplete="off" required
+               data-on:keydown="evt.key==='Escape' && ($editing=false)">
+        <button type="button" class="cancel-touch"
+                data-on:click="$editing=false">&#x2717;</button>
+      </form>
+    </div>
+    <div data-on:click="evt.target.closest('.edit-btn') && ($editing=true, $editchar=evt.target.closest('.edit-btn').dataset.char, $initval='')">
       <table>
         <thead>
-          <tr><th>Character</th><th>Player</th></tr>
+          <tr><th>#</th><th>Init</th><th>Character</th><th>Player</th></tr>
         </thead>
-        <tbody id="idle-rows"></tbody>
+        <tbody id="initiative-rows">
+          <tr><td colspan="4">Alea nondum iacta est…</td></tr>
+        </tbody>
       </table>
-    </section>
+      <section class="idle-section">
+        <h2>Idle Characters</h2>
+        <table>
+          <thead>
+            <tr><th>Init</th><th>Character</th><th>Player</th></tr>
+          </thead>
+          <tbody id="idle-rows"></tbody>
+        </table>
+      </section>
+    </div>
   </div>
 </body>
 </html>

--- a/tests/web/test_tracker.py
+++ b/tests/web/test_tracker.py
@@ -9,6 +9,7 @@ from starlette.testclient import TestClient
 
 import initbot_core.state.state as state_module
 import initbot_web.routes.tracker as tracker_module
+from initbot_core.data.character import NewCharacterData
 from initbot_core.state.factory import create_state_from_source
 from initbot_core.state.state import _SESSION_SECRET_TTL
 from initbot_web.app import create_app
@@ -202,6 +203,82 @@ def test_session_survives_restart(tmp_path):
         client2.cookies.update(cookies)
         resp = client2.get("/testsecret/tracker/")
         assert resp.status_code == 200
+
+
+# ── set-initiative endpoint ───────────────────────────────────────────────────
+
+
+def _make_app_with_character(tmp_path):
+    """Return (app, state, char_name) with one character in the DB."""
+    db_path = tmp_path / "test.db"
+    state = create_state_from_source(f"sqlite:{db_path}")
+    player = state.players.upsert(discord_id=99, name="Tester")
+    assert player.id is not None
+    char = state.characters.add_store_and_get(
+        NewCharacterData(name="Aldric", player_id=player.id)
+    )
+    settings = WebSettings(state=f"sqlite:{db_path}")
+    app = create_app(settings, web_url_path_prefix="testsecret")
+    return app, state, char.name
+
+
+def test_set_initiative_requires_auth(tmp_path):
+    app, _, char_name = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": char_name, "initval": 10},
+        )
+        assert resp.status_code == 403
+
+
+def test_set_initiative_updates_character(tmp_path):
+    app, state, _ = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric", "initval": 17},
+        )
+        assert resp.status_code == 200
+        assert state.characters.get_from_name("Aldric").initiative == 17
+
+
+def test_set_initiative_unknown_character_returns_2xx_no_change(tmp_path):
+    app, _, _ = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "NoSuchCharacter", "initval": 5},
+        )
+        assert resp.status_code in (200, 204)
+
+
+def test_set_initiative_out_of_range_returns_200_no_change(tmp_path):
+    app, state, _ = _make_app_with_character(tmp_path)
+    char = state.characters.get_from_name("Aldric")
+    char.initiative = 10
+    state.characters.update_and_store(char)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric", "initval": 999},
+        )
+        assert resp.status_code in (200, 204)
+        assert state.characters.get_from_name("Aldric").initiative == 10
+
+
+def test_set_initiative_missing_initval_returns_2xx_no_change(tmp_path):
+    app, _, _ = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric"},
+        )
+        assert resp.status_code in (200, 204)
 
 
 def test_session_invalidated_after_secret_expiry(tmp_path, monkeypatch):

--- a/tools/run_playwright.sh
+++ b/tools/run_playwright.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Stefan Götz <github.nooneelse@spamgourmet.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Start the Playwright MCP server outside the nono sandbox.
+# Run this in a separate terminal before starting Claude Code with nono.
+# The server listens on http://localhost:8931/sse and Claude Code connects
+# to it via SSE transport, bypassing sandbox restrictions on browser processes.
+
+set -ue
+
+exec npx --yes @playwright/mcp@latest --headless --isolated --browser chrome --port 8931


### PR DESCRIPTION
## Summary

- New `POST /tracker/set-initiative` endpoint validates and persists initiative values
- Edit panel above the table, driven by Datastar signals — no server-side lock, live SSE updates continue during editing
- ✏ buttons on all active and idle character rows; idle characters move into the active order on submit
- Enter confirms, Escape cancels, touch-only ✗ button for mobile cancel