### PR TITLE
Allow dice expressions in the web initiative edit form

### DIFF
--- a/packages/initbot-chat/src/initbot_chat/commands/character.py
+++ b/packages/initbot-chat/src/initbot_chat/commands/character.py
@@ -35,8 +35,6 @@ async def init_dice(ctx: commands.Context, *args: str) -> None:
     - `$init_dice d20+3` — roll d20 and add 3
     - `$init_dice Alfalfa d20+3` — set spec for the named character
 
-    Setting the dice spec clears any previously rolled initiative value.
-
     If the Discord user manages only a single character, the character name is
     optional and can be omitted.  If there is no character with the given name,
     a new character with that name is created.
@@ -64,7 +62,6 @@ async def init_dice(ctx: commands.Context, *args: str) -> None:
         name, create=len(name) > 0, player_id=player.id
     )
     cdi.initiative_dice = spec
-    cdi.initiative = None
     cdi.last_used = int(time.time())
     ctx.bot.initbot_state.characters.update_and_store(cdi)
     await ctx.send(f"{cdi.name}'s initiative dice is now {spec}", delete_after=3)

--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -19,12 +19,16 @@ from starlette.routing import Mount, Route
 from starlette.templating import Jinja2Templates
 
 from initbot_core.data.character import CharacterData
+from initbot_core.models.roll import DiceExpression
 from initbot_core.security import VulnerabilityState
 from initbot_core.state.state import State
 
 POLL_INTERVAL = 1.5
 STALE_SECONDS = 24 * 3600
 SESSION_TTL: Final[int] = 8 * 3600
+_INITIATIVE_INPUT_ERROR = (
+    "Enter a number from \u221299 to 99, or a dice formula like d20+5."
+)
 
 _log = logging.getLogger(__name__)
 
@@ -180,17 +184,34 @@ def make_routes(  # pylint: disable=too-many-locals,too-many-statements
     ) -> DatastarEvent | tuple[()]:
         data = await request.json()
         char_name: str = data.get("editchar", "")
+        initval: str = str(data.get("initval", "")).strip()
+
+        if not initval:
+            return SSE.patch_signals({"editerror": _INITIATIVE_INPUT_ERROR})
+
+        as_integer: int | None = None
         try:
-            initiative = int(data.get("initval", ""))
-            if initiative < -99 or initiative > 99:
-                return ()
+            as_integer = int(initval)
+            if as_integer < -99 or as_integer > 99:
+                return SSE.patch_signals({"editerror": _INITIATIVE_INPUT_ERROR})
+        except ValueError:
+            try:
+                DiceExpression.create(initval)
+            except ValueError:
+                return SSE.patch_signals({"editerror": _INITIATIVE_INPUT_ERROR})
+
+        try:
             char = state.characters.get_from_name(char_name)
         except (TypeError, ValueError, KeyError):
             return ()
-        char.initiative = initiative
+
+        if as_integer is not None:
+            char.initiative = as_integer
+        else:
+            char.initiative_dice = initval
         char.last_used = int(time.time())
         state.characters.update_and_store(char)
-        return SSE.patch_signals({"editing": False})
+        return SSE.patch_signals({"editing": False, "editerror": ""})
 
     async def set_initiative(request: Request) -> Response:
         if (err := _require_auth(request)) is not None:

--- a/packages/initbot-web/src/initbot_web/templates/tracker.html
+++ b/packages/initbot-web/src/initbot_web/templates/tracker.html
@@ -197,7 +197,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     }
 
     #edit-input {
-      width: 5rem;
+      width: 15rem;
       font-family: var(--font-main);
       font-size: 1rem;
       color: var(--color-gold);
@@ -324,16 +324,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <div id="security-alert">{% if has_high_severity_vulnerabilities %}<p>This application needs to receive a security update.</p>{% endif %}</div>
   <h1>Initiative Order</h1>
   <div data-init="@get('{{ sse_url }}')"
-       data-signals='{"editing": false, "editchar": "", "initval": ""}'>
+       data-signals='{"editing": false, "editchar": "", "initval": "", "editerror": ""}'>
     <div id="edit-panel" data-show="$editing" style="display: none">
       <span id="edit-label" data-text="$editchar"></span>
       <form data-on:submit__prevent="@post('{{ set_initiative_url }}')"
             data-effect="$editing && setTimeout(() => document.getElementById('edit-input')?.focus(), 0)">
-        <input id="edit-input" type="number" data-bind:initval
-               min="-99" max="99" autocomplete="off" required
-               data-on:keydown="evt.key==='Escape' && ($editing=false)">
+        <input id="edit-input" type="text" data-bind:initval
+               autocomplete="off" placeholder="e.g. 17 or d20+3"
+               data-on:keydown="evt.key==='Escape' && ($editing=false)"
+               data-on:input="$editerror=''">
         <button type="button" class="cancel-touch"
                 data-on:click="$editing=false">&#x2717;</button>
+        <p id="edit-error" data-show="$editerror" data-text="$editerror" style="display:none"></p>
       </form>
     </div>
     <div data-on:click="evt.target.closest('.edit-btn') && ($editing=true, $editchar=evt.target.closest('.edit-btn').dataset.char, $initval='')">

--- a/tests/test_commands_chars.py
+++ b/tests/test_commands_chars.py
@@ -5,7 +5,14 @@
 import pytest
 from discord.ext import commands
 
-from initbot_chat.commands.character import char, char_error, chars, remove, rename
+from initbot_chat.commands.character import (
+    char,
+    char_error,
+    chars,
+    init_dice,
+    remove,
+    rename,
+)
 from initbot_core.data.character import NewCharacterData
 
 
@@ -133,6 +140,16 @@ async def test_rename_conflict_case_insensitive(mock_ctx):
     )
     with pytest.raises(ValueError, match="Beta"):
         await rename.callback(mock_ctx, "Alpha", "beta")
+
+
+async def test_init_dice_sets_spec_preserves_initiative(mock_ctx):
+    mock_ctx.bot.initbot_state.characters.add_store_and_get(
+        NewCharacterData(name="Mel", player_id=mock_ctx.author.player_id, initiative=14)
+    )
+    await init_dice.callback(mock_ctx, "d20+3")
+    updated = mock_ctx.bot.initbot_state.characters.get_from_name("Mel")
+    assert updated.initiative_dice == "d20+3"
+    assert updated.initiative == 14
 
 
 async def test_rename_preserves_actions(mock_ctx):

--- a/tests/web/test_tracker.py
+++ b/tests/web/test_tracker.py
@@ -255,7 +255,7 @@ def test_set_initiative_unknown_character_returns_2xx_no_change(tmp_path):
         assert resp.status_code in (200, 204)
 
 
-def test_set_initiative_out_of_range_returns_200_no_change(tmp_path):
+def test_set_initiative_out_of_range_returns_error_signal(tmp_path):
     app, state, _ = _make_app_with_character(tmp_path)
     char = state.characters.get_from_name("Aldric")
     char.initiative = 10
@@ -268,9 +268,10 @@ def test_set_initiative_out_of_range_returns_200_no_change(tmp_path):
         )
         assert resp.status_code in (200, 204)
         assert state.characters.get_from_name("Aldric").initiative == 10
+        assert "editerror" in resp.text
 
 
-def test_set_initiative_missing_initval_returns_2xx_no_change(tmp_path):
+def test_set_initiative_missing_initval_returns_error_signal(tmp_path):
     app, _, _ = _make_app_with_character(tmp_path)
     with TestClient(app, follow_redirects=False) as client:
         client.post(f"/testsecret/{app.state.admin_token}/")
@@ -279,6 +280,47 @@ def test_set_initiative_missing_initval_returns_2xx_no_change(tmp_path):
             json={"editchar": "Aldric"},
         )
         assert resp.status_code in (200, 204)
+        assert "editerror" in resp.text
+
+
+def test_set_initiative_invalid_input_returns_error_signal(tmp_path):
+    app, _, _ = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric", "initval": "notvalid"},
+        )
+        assert resp.status_code in (200, 204)
+        assert "editerror" in resp.text
+
+
+def test_set_initiative_dice_expression_stores_dice(tmp_path):
+    app, state, _ = _make_app_with_character(tmp_path)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        resp = client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric", "initval": "d20+5"},
+        )
+        assert resp.status_code == 200
+        assert state.characters.get_from_name("Aldric").initiative_dice == "d20+5"
+
+
+def test_set_initiative_dice_expression_preserves_existing_initiative(tmp_path):
+    app, state, _ = _make_app_with_character(tmp_path)
+    char = state.characters.get_from_name("Aldric")
+    char.initiative = 10
+    state.characters.update_and_store(char)
+    with TestClient(app, follow_redirects=False) as client:
+        client.post(f"/testsecret/{app.state.admin_token}/")
+        client.post(
+            "/testsecret/tracker/set-initiative",
+            json={"editchar": "Aldric", "initval": "d20+5"},
+        )
+        updated = state.characters.get_from_name("Aldric")
+        assert updated.initiative_dice == "d20+5"
+        assert updated.initiative == 10
 
 
 def test_session_invalidated_after_secret_expiry(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- The tracker's initiative edit input now accepts both plain numbers (−99 to 99) and dice formulas (e.g. `d20+5`). The backend detects which kind of input was received and writes it to `character.initiative` or `character.initiative_dice` independently, leaving the other field untouched.
- Invalid input returns a friendly inline error signal ("Enter a number from −99 to 99, or a dice formula like d20+5."); the edit panel stays open and the error clears on the next keystroke.
- The input is a `type="text"` field with a `placeholder="e.g. 17 or d20+3"` hint and width widened from 5 rem to 15 rem.
- The Discord `$init_dice` command no longer clears `character.initiative` when a new dice spec is set, matching the new web behaviour.

## Test plan

- [ ] Playwright-tested: dice expression stores `initiative_dice`, preserves `initiative`; invalid input shows inline error; error clears on typing; numeric value updates `initiative`; empty submit shows error.
- [ ] Unit tests added for all new code paths in `tests/web/test_tracker.py` and `tests/test_commands_chars.py`.
- [ ] All pre-commit hooks (ruff, pylint, ty, pytest) pass.