### PR TITLE
Split initiative display and character interaction into two tables

### DIFF
--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -360,15 +360,16 @@ def _render_rows(chars_with_names: list[tuple[CharacterData, str]]) -> str:
     if not chars_with_names:
         return (
             '<tbody id="initiative-rows">'
-            '<tr><td colspan="2">Alea nondum iacta est\u2026</td></tr>'
+            '<tr><td colspan="3">Alea nondum iacta est\u2026</td></tr>'
             "</tbody>"
         )
     rows = "".join(
         f'<tr id="r{i}">'
-        f"<td>{_safe_int(c.initiative)}</td>"
         f"<td>{_safe_str(c.name)}</td>"
+        f"<td>{_safe_str(name)}</td>"
+        f"<td>{_safe_int(c.initiative)}</td>"
         f"</tr>"
-        for i, (c, _) in enumerate(chars_with_names)
+        for i, (c, name) in enumerate(chars_with_names)
     )
     return f'<tbody id="initiative-rows">{rows}</tbody>'
 

--- a/packages/initbot-web/src/initbot_web/routes/tracker.py
+++ b/packages/initbot-web/src/initbot_web/routes/tracker.py
@@ -129,11 +129,21 @@ def make_routes(  # pylint: disable=too-many-locals,too-many-statements
     @datastar_response
     async def _tracker_sse(request: Request) -> AsyncGenerator[DatastarEvent, None]:
         last_snapshot: tuple[tuple[str, int | None, str | None], ...] = ()
-        last_idle_snapshot: tuple[tuple[str, str | None], ...] = ()
+        last_char_snapshot: tuple[tuple[str, int | None, str | None, str], ...] = ()
         last_vuln = vuln_state.has_high_severity_vulnerabilities
+
+        discord_id: int | None = request.session.get("discord_id")
+        logged_in_player = (
+            state.players.get_from_discord_id(discord_id)
+            if discord_id is not None
+            else None
+        )
+        logged_in_player_id = logged_in_player.id if logged_in_player else None
+
         while not await request.is_disconnected():
             now = int(datetime.now().timestamp())
             all_chars = state.characters.get_all()
+
             chars = [
                 c
                 for c in all_chars
@@ -142,34 +152,38 @@ def make_routes(  # pylint: disable=too-many-locals,too-many-statements
                 and c.last_used > now - STALE_SECONDS
             ]
             chars.sort(key=lambda c: c.initiative or 0, reverse=True)
-            idle_chars = [
-                c
-                for c in all_chars
-                if c.initiative is None
-                and c.last_used is not None
-                and c.last_used > now - STALE_SECONDS
-            ]
-            idle_chars.sort(key=lambda c: c.name)
-
             chars_with_names = [(c, _resolve_player_name(state, c)) for c in chars]
             snapshot = tuple(
                 (c.name, c.initiative, c.initiative_dice) for c, _ in chars_with_names
             )
             if snapshot != last_snapshot:
                 last_snapshot = snapshot
-                yield SSE.patch_elements(
-                    _render_rows(
-                        chars_with_names, delete_character_url, roll_initiative_url
-                    )
-                )
+                yield SSE.patch_elements(_render_rows(chars_with_names))
 
-            idle_with_names = [(c, _resolve_player_name(state, c)) for c in idle_chars]
-            idle_snapshot = tuple((c.name, c.initiative_dice) for c in idle_chars)
-            if idle_snapshot != last_idle_snapshot:
-                last_idle_snapshot = idle_snapshot
+            my_chars = sorted(
+                [c for c in all_chars if c.player_id == logged_in_player_id],
+                key=lambda c: c.name,
+            )
+            other_chars = sorted(
+                [c for c in all_chars if c.player_id != logged_in_player_id],
+                key=lambda c: c.name,
+            )
+            all_chars_ordered = my_chars + other_chars
+            all_with_names = [
+                (c, _resolve_player_name(state, c)) for c in all_chars_ordered
+            ]
+            char_snapshot = tuple(
+                (c.name, c.initiative, c.initiative_dice, name)
+                for c, name in all_with_names
+            )
+            if char_snapshot != last_char_snapshot:
+                last_char_snapshot = char_snapshot
                 yield SSE.patch_elements(
-                    _render_idle_rows(
-                        idle_with_names, delete_character_url, roll_initiative_url
+                    _render_char_rows(
+                        all_with_names,
+                        roll_initiative_url,
+                        delete_character_url,
+                        len(my_chars),
                     )
                 )
 
@@ -342,48 +356,61 @@ def _render_delete_button(char_name: str, delete_url_prefix: str) -> str:
     )
 
 
-def _render_rows(
-    chars_with_names: list[tuple[CharacterData, str]],
-    delete_url_prefix: str,
-    roll_url_prefix: str,
-) -> str:
+def _render_rows(chars_with_names: list[tuple[CharacterData, str]]) -> str:
+    if not chars_with_names:
+        return (
+            '<tbody id="initiative-rows">'
+            '<tr><td colspan="2">Alea nondum iacta est\u2026</td></tr>'
+            "</tbody>"
+        )
     rows = "".join(
         f'<tr id="r{i}">'
-        f"<td>{i + 1}</td>"
-        f'<td><span class="init-val">{_safe_int(c.initiative)}</span>'
-        f" {_render_edit_button(c.name)}"
-        f"{_render_roll_button(c.name, roll_url_prefix) if _has_valid_dice(c.initiative_dice) else ''}"
-        f"</td>"
+        f"<td>{_safe_int(c.initiative)}</td>"
         f"<td>{_safe_str(c.name)}</td>"
-        f"<td>{_safe_str(name)}</td>"
-        f"<td>{_render_delete_button(c.name, delete_url_prefix)}</td>"
         f"</tr>"
-        for i, (c, name) in enumerate(chars_with_names)
+        for i, (c, _) in enumerate(chars_with_names)
     )
     return f'<tbody id="initiative-rows">{rows}</tbody>'
 
 
-def _render_idle_rows(
+def _render_char_rows(
     chars_with_names: list[tuple[CharacterData, str]],
-    delete_url_prefix: str,
     roll_url_prefix: str,
+    delete_url_prefix: str,
+    my_chars_count: int,
 ) -> str:
-    rows = "".join(
-        f"<tr>"
-        f"<td>{_render_edit_button(c.name)}"
-        f"{_render_roll_button(c.name, roll_url_prefix) if _has_valid_dice(c.initiative_dice) else ''}"
-        f"</td>"
-        f"<td>{_safe_str(c.name)}</td>"
-        f"<td>{_safe_str(name)}</td>"
-        f"<td>{_render_delete_button(c.name, delete_url_prefix)}</td>"
-        f"</tr>"
-        for c, name in chars_with_names
-    )
-    return f'<tbody id="idle-rows">{rows}</tbody>'
+    rows = []
+    for i, (c, player_name) in enumerate(chars_with_names):
+        separator = ' class="group-separator"' if i == my_chars_count > 0 else ""
+        roll_btn = (
+            _render_roll_button(c.name, roll_url_prefix)
+            if _has_valid_dice(c.initiative_dice)
+            else ""
+        )
+        rows.append(
+            f"<tr{separator}>"
+            f"<td>{_safe_str(c.name)}</td>"
+            f"<td>{_safe_str(player_name)}</td>"
+            f"<td>{_safe_int(c.initiative)}</td>"
+            f"<td>{_safe_dice(c.initiative_dice)}</td>"
+            f"<td>{_render_edit_button(c.name)}</td>"
+            f"<td>{roll_btn}</td>"
+            f"<td>{_render_delete_button(c.name, delete_url_prefix)}</td>"
+            f"</tr>"
+        )
+    return f'<tbody id="char-rows">{"".join(rows)}</tbody>'
 
 
 def _safe_int(value: int | None) -> str:
-    return re.sub(r"[^\d]", "", str(value))
+    if value is None:
+        return ""
+    return str(int(value))
+
+
+def _safe_dice(value: str | None) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[^a-zA-Z0-9+\-*/() ]", "", value)
 
 
 def _safe_str(value: str) -> str:

--- a/packages/initbot-web/src/initbot_web/templates/tracker.html
+++ b/packages/initbot-web/src/initbot_web/templates/tracker.html
@@ -127,17 +127,29 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       vertical-align: middle;
     }
 
+    /* ── Shared table layout for column alignment ──────────────── */
+    #initiative-table,
+    .char-section table {
+      table-layout: fixed;
+    }
+
     /* ── Initiative table column styles ────────────────────────── */
-    /* Init value — gold, bold */
+    /* Character name — bold */
     #initiative-rows td:first-child {
+      font-weight: 700;
+    }
+
+    /* Player name — muted */
+    #initiative-rows td:nth-child(2) {
+      color: rgba(26, 18, 9, 0.65);
+      font-size: 0.9rem;
+    }
+
+    /* Init value — gold, bold */
+    #initiative-rows td:nth-child(3) {
       font-weight: 700;
       font-size: 1.05rem;
       color: var(--color-gold);
-    }
-
-    /* Character name — bold */
-    #initiative-rows td:nth-child(2) {
-      font-weight: 700;
     }
 
     /* ── Character table column styles ─────────────────────────── */
@@ -342,12 +354,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <div data-init="@get('{{ sse_url }}')"
        data-signals='{"editing": false, "editchar": "", "initval": "", "editerror": ""}'>
     <div data-on:click="evt.target.closest('.edit-btn') && ($editing=true, $editchar=evt.target.closest('.edit-btn').dataset.char, $initval='')">
-      <table>
+      <table id="initiative-table">
+        <colgroup>
+          <col style="width: 40%">
+          <col style="width: 18%">
+        </colgroup>
         <thead>
-          <tr><th>Init</th><th>Character</th></tr>
+          <tr><th>Character</th><th>Player</th><th>Init</th></tr>
         </thead>
         <tbody id="initiative-rows">
-          <tr><td colspan="2">Alea nondum iacta est…</td></tr>
+          <tr><td colspan="3">Alea nondum iacta est…</td></tr>
         </tbody>
       </table>
       <section class="char-section">
@@ -366,6 +382,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           </form>
         </div>
         <table>
+          <colgroup>
+            <col style="width: 40%">
+            <col style="width: 18%">
+            <col style="width: 10%">
+            <col style="width: 14%">
+          </colgroup>
           <thead>
             <tr><th>Character</th><th>Player</th><th>Init</th><th>Dice</th><th></th><th></th><th></th></tr>
           </thead>

--- a/packages/initbot-web/src/initbot_web/templates/tracker.html
+++ b/packages/initbot-web/src/initbot_web/templates/tracker.html
@@ -114,10 +114,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       letter-spacing: 0.12em;
     }
 
-    thead th:first-child {
-      text-align: center;
-    }
-
     tbody tr {
       border-bottom: 1px solid rgba(74, 71, 66, 0.25);
     }
@@ -131,29 +127,51 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       vertical-align: middle;
     }
 
-    /* Rank — muted, centered */
-    tbody td:first-child {
-      text-align: center;
-      color: rgba(26, 18, 9, 0.45);
-      font-size: 0.85rem;
-    }
-
-    /* Initiative value — gold, bold, primary scan target */
-    tbody td:nth-child(2) {
+    /* ── Initiative table column styles ────────────────────────── */
+    /* Init value — gold, bold */
+    #initiative-rows td:first-child {
       font-weight: 700;
       font-size: 1.05rem;
       color: var(--color-gold);
     }
 
     /* Character name — bold */
-    tbody td:nth-child(3) {
+    #initiative-rows td:nth-child(2) {
+      font-weight: 700;
+    }
+
+    /* ── Character table column styles ─────────────────────────── */
+    /* Character name — bold */
+    #char-rows td:first-child {
       font-weight: 700;
     }
 
     /* Player name — muted */
-    tbody td:nth-child(4) {
+    #char-rows td:nth-child(2) {
       color: rgba(26, 18, 9, 0.65);
       font-size: 0.9rem;
+    }
+
+    /* Init value — gold, bold */
+    #char-rows td:nth-child(3) {
+      font-weight: 700;
+      font-size: 1.05rem;
+      color: var(--color-gold);
+    }
+
+    /* Dice expression — muted */
+    #char-rows td:nth-child(4) {
+      color: rgba(26, 18, 9, 0.65);
+      font-size: 0.9rem;
+    }
+
+    /* Action columns (edit, die, delete) — narrow, centred */
+    #char-rows td:nth-child(5),
+    #char-rows td:nth-child(6),
+    #char-rows td:nth-child(7) {
+      width: 2rem;
+      text-align: center;
+      padding: 0.6rem 0.25rem;
     }
 
     /* Top-ranked combatant: gold left-accent */
@@ -280,34 +298,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       }
     }
 
-    /* ── Idle Characters section ──────────────────────────────── */
-    .idle-section {
+    /* ── Characters section ───────────────────────────────────── */
+    .char-section {
       margin-top: 2.5rem;
-      opacity: 0.5;
     }
 
-    /* Init column — edit button cell */
-    .idle-section tbody td:first-child {
-      text-align: center;
-      width: 3rem;
-    }
-
-    /* Character name — bold (mirrors initiative table's 3rd column) */
-    .idle-section tbody td:nth-child(2) {
-      font-weight: 700;
-      text-align: left;
-      color: var(--color-ink);
-      font-size: 1rem;
-    }
-
-    /* Player name — muted (mirrors initiative table's 4th column) */
-    .idle-section tbody td:nth-child(3) {
-      font-weight: 400;
-      font-size: 0.9rem;
-      color: rgba(26, 18, 9, 0.65);
-    }
-
-    .idle-section h2 {
+    .char-section h2 {
       font-family: var(--font-main);
       font-size: clamp(1rem, 2.5vw, 1.4rem);
       font-weight: 700;
@@ -317,8 +313,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       text-align: center;
       width: fit-content;
       margin: 0 auto 1rem;
-      border-bottom: 2px solid var(--color-offset);
+      border-bottom: 2px solid var(--color-gold);
       padding-bottom: 0.3rem;
+    }
+
+    /* ── Group separator row ──────────────────────────────────── */
+    tr.group-separator td {
+      border-top: 2px solid rgba(74, 71, 66, 0.4);
     }
 
     /* ── Responsive ───────────────────────────────────────────── */
@@ -340,35 +341,35 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <h1>Initiative Order</h1>
   <div data-init="@get('{{ sse_url }}')"
        data-signals='{"editing": false, "editchar": "", "initval": "", "editerror": ""}'>
-    <div id="edit-panel" data-show="$editing" style="display: none">
-      <span id="edit-label" data-text="$editchar"></span>
-      <form data-on:submit__prevent="@post('{{ set_initiative_url }}')"
-            data-effect="$editing && setTimeout(() => document.getElementById('edit-input')?.focus(), 0)">
-        <input id="edit-input" type="text" data-bind:initval
-               autocomplete="off" placeholder="e.g. 17 or d20+3"
-               data-on:keydown="evt.key==='Escape' && ($editing=false)"
-               data-on:input="$editerror=''">
-        <button type="button" class="cancel-touch"
-                data-on:click="$editing=false">&#x2717;</button>
-        <p id="edit-error" data-show="$editerror" data-text="$editerror" style="display:none"></p>
-      </form>
-    </div>
     <div data-on:click="evt.target.closest('.edit-btn') && ($editing=true, $editchar=evt.target.closest('.edit-btn').dataset.char, $initval='')">
       <table>
         <thead>
-          <tr><th>#</th><th>Init</th><th>Character</th><th>Player</th><th></th></tr>
+          <tr><th>Init</th><th>Character</th></tr>
         </thead>
         <tbody id="initiative-rows">
-          <tr><td colspan="4">Alea nondum iacta est…</td></tr>
+          <tr><td colspan="2">Alea nondum iacta est…</td></tr>
         </tbody>
       </table>
-      <section class="idle-section">
-        <h2>Idle Characters</h2>
+      <section class="char-section">
+        <h2>Characters</h2>
+        <div id="edit-panel" data-show="$editing" style="display: none">
+          <span id="edit-label" data-text="$editchar"></span>
+          <form data-on:submit__prevent="@post('{{ set_initiative_url }}')"
+                data-effect="$editing && setTimeout(() => document.getElementById('edit-input')?.focus(), 0)">
+            <input id="edit-input" type="text" data-bind:initval
+                   autocomplete="off" placeholder="e.g. 17 or d20+3"
+                   data-on:keydown="evt.key==='Escape' && ($editing=false)"
+                   data-on:input="$editerror=''">
+            <button type="button" class="cancel-touch"
+                    data-on:click="$editing=false">&#x2717;</button>
+            <p id="edit-error" data-show="$editerror" data-text="$editerror" style="display:none"></p>
+          </form>
+        </div>
         <table>
           <thead>
-            <tr><th>Init</th><th>Character</th><th>Player</th><th></th></tr>
+            <tr><th>Character</th><th>Player</th><th>Init</th><th>Dice</th><th></th><th></th><th></th></tr>
           </thead>
-          <tbody id="idle-rows"></tbody>
+          <tbody id="char-rows"></tbody>
         </table>
       </section>
     </div>


### PR DESCRIPTION
## Summary

- The initiative table now shows only Character, Player, and Init columns — no interactive elements on a dynamically reordering surface
- A new **Characters** table replaces the idle characters section: lists every known character (no staleness filter), with the logged-in player's characters first then all others, each group sorted alphabetically, separated by a thicker row border
- All interactive controls (edit, dice roll, delete) move to the stable character table; the edit panel appears above it
- Both tables use `table-layout: fixed` with matching column widths so Character, Player, and Init columns align vertically
- Fixes a pre-existing bug where negative initiative values lost their minus sign in `_safe_int()`
- Adds `_safe_dice()` so dice expressions containing `+`, `-`, `/` display correctly in the Dice column

## Test plan

- [x] Initiative table shows Character, Player, Init columns only — no buttons, sorted descending, gold accent on top row
- [x] Character table shows all characters (including those with no initiative set)
- [x] Logged-in player's characters appear first (alphabetically), then others; thicker separator border between groups
- [x] Edit panel appears above the character table (not the initiative table); dismisses on Escape and successful submit
- [x] Die icon rolls initiative and updates both tables; only appears for characters with a valid dice formula
- [x] Delete removes the character from both tables
- [x] Admin session: all characters in one group, no separator
- [x] Column edges for Character, Player, Init align visually between the two tables