### PR TITLE
Replace Peewee ORM with stdlib sqlite3

### DIFF
--- a/packages/initbot-core/pyproject.toml
+++ b/packages/initbot-core/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "peewee~=4.0",
     "pydantic-settings~=2.0",
     "pydantic~=2.0",
     "python-dotenv~=1.2",

--- a/packages/initbot-core/src/initbot_core/data/character.py
+++ b/packages/initbot-core/src/initbot_core/data/character.py
@@ -4,7 +4,6 @@
 
 import time
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
 
 
 @dataclass
@@ -18,15 +17,15 @@ class NewCharacterData:
     last_used: int | None = None
 
 
-@runtime_checkable
-class CharacterData(Protocol):
-    """Data handle — the storage-native object returned by get_all() and mutated in place."""
+@dataclass
+class CharacterData:
+    """Data handle returned by the storage layer and mutated in place before update_and_store."""
 
     name: str
-    initiative: int | None
-    initiative_dice: str | None
-    last_used: int | None
     player_id: int
+    initiative: int | None = None
+    initiative_dice: str | None = None
+    last_used: int | None = None
 
 
 def is_eligible_for_pruning(cdi: CharacterData, threshold_days: int) -> bool:

--- a/packages/initbot-core/src/initbot_core/data/player.py
+++ b/packages/initbot-core/src/initbot_core/data/player.py
@@ -2,15 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from typing import Protocol, runtime_checkable
+from dataclasses import dataclass
 
 
-# Implementations (LocalPlayerData, _SqlPlayerData) satisfy this Protocol structurally.
-# Explicit inheritance is not possible: _ProtocolMeta (typing.Protocol), Pydantic's
-# ModelMetaclass, and Peewee's ModelBase are all ABCMeta subclasses but none is a subclass
-# of another, so Python raises TypeError: metaclass conflict at class definition time.
-@runtime_checkable
-class PlayerData(Protocol):
+@dataclass
+class PlayerData:
     id: int  # Internal primary key, auto-assigned, used as foreign key by other entities
     discord_id: int  # Discord snowflake
     name: str  # Display name, refreshed on each command invocation

--- a/packages/initbot-core/src/initbot_core/state/sql.py
+++ b/packages/initbot-core/src/initbot_core/state/sql.py
@@ -3,21 +3,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import secrets
+import sqlite3
 import time
 from collections.abc import Sequence
-from dataclasses import asdict
-from inspect import isclass
 from pathlib import Path
-from typing import cast
-
-from peewee import (
-    AutoField,
-    BooleanField,
-    CharField,
-    IntegerField,
-    Model,
-    SqliteDatabase,
-)
 
 from initbot_core.config import CORE_CFG
 from initbot_core.data.character import CharacterData, NewCharacterData
@@ -33,320 +22,362 @@ from initbot_core.state.state import (
 )
 from initbot_core.state.validation import check_state_directory
 
-
-class _SqlCharacterData(Model):
-    name = CharField(unique=True, primary_key=True)
-    initiative = IntegerField(null=True)
-    initiative_dice = CharField(null=True)
-    last_used = IntegerField(null=True)
-    player_id = IntegerField(null=True)
+_CREATE_TABLES = """
+CREATE TABLE IF NOT EXISTS _sqlcharacterdata (
+    name TEXT NOT NULL PRIMARY KEY,
+    player_id INTEGER,
+    initiative INTEGER,
+    initiative_dice TEXT,
+    last_used INTEGER
+);
+CREATE TABLE IF NOT EXISTS _sqlplayerdata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    discord_id INTEGER UNIQUE,
+    name TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS _sqlcharacteraction (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    character_name TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    template TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS _sqlweblogintoken (
+    token TEXT PRIMARY KEY,
+    discord_id INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    used INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS _sqlsessionsecret (
+    id INTEGER PRIMARY KEY,
+    secret TEXT NOT NULL,
+    expires_at INTEGER NOT NULL
+);
+"""
 
 
 class _SqlCharacterState(CharacterState):
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+
     def get_all(self) -> Sequence[CharacterData]:
-        return tuple(_SqlCharacterData.select())
+        rows = self._db.execute(
+            "SELECT name, player_id, initiative, initiative_dice, last_used"
+            " FROM _sqlcharacterdata"
+        ).fetchall()
+        return [CharacterData(*row) for row in rows]
 
     def _add_store_and_get(self, char_data: NewCharacterData) -> CharacterData:
-        if char_data.last_used is None:
-            char_data.last_used = int(time.time())
-        return cast(
-            CharacterData,
-            _SqlCharacterData.create(**{
-                k: v for k, v in asdict(char_data).items() if v is not None
-            }),
+        last_used = (
+            char_data.last_used if char_data.last_used is not None else int(time.time())
         )
-
-    def remove_and_store(self, char_data: CharacterData) -> None:
-        _SqlCharacterData.delete().where(
-            _SqlCharacterData.name == char_data.name
-        ).execute()
+        self._db.execute(
+            "INSERT INTO _sqlcharacterdata (name, player_id, initiative, initiative_dice, last_used)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (
+                char_data.name,
+                char_data.player_id,
+                char_data.initiative,
+                char_data.initiative_dice,
+                last_used,
+            ),
+        )
+        return CharacterData(
+            name=char_data.name,
+            player_id=char_data.player_id,
+            initiative=char_data.initiative,
+            initiative_dice=char_data.initiative_dice,
+            last_used=last_used,
+        )
 
     def _rename_and_store(
         self, char_data: CharacterData, new_name: str
     ) -> CharacterData:
-        _SqlCharacterData.update(name=new_name).where(
-            _SqlCharacterData.name == char_data.name
-        ).execute()
-        return _SqlCharacterData.get(_SqlCharacterData.name == new_name)  # type: ignore[return-value]
+        self._db.execute(
+            "UPDATE _sqlcharacterdata SET name=? WHERE name=?",
+            (new_name, char_data.name),
+        )
+        return CharacterData(
+            name=new_name,
+            player_id=char_data.player_id,
+            initiative=char_data.initiative,
+            initiative_dice=char_data.initiative_dice,
+            last_used=char_data.last_used,
+        )
 
     def update_and_store(self, char_data: CharacterData) -> None:
-        if not isinstance(char_data, _SqlCharacterData):
-            raise TypeError(
-                f"Only character data returned by the State class can be updated: {char_data}"
-            )
-        # pylint: disable-next=protected-access
-        meta = type(char_data)._meta
-        pk_name = meta.primary_key.name
-        fields_to_update = {
-            field: char_data.__data__.get(name)
-            for name, field in meta.fields.items()
-            if name != pk_name
-        }
-        _SqlCharacterData.update(fields_to_update).where(
-            _SqlCharacterData.name == char_data.name
-        ).execute()
+        self._db.execute(
+            "UPDATE _sqlcharacterdata"
+            " SET player_id=?, initiative=?, initiative_dice=?, last_used=?"
+            " WHERE name=?",
+            (
+                char_data.player_id,
+                char_data.initiative,
+                char_data.initiative_dice,
+                char_data.last_used,
+                char_data.name,
+            ),
+        )
 
-
-class _SqlPlayerData(Model):
-    id = AutoField()  # internal primary key, auto-increment
-    discord_id = IntegerField(null=True, unique=True)
-    name = CharField()
+    def remove_and_store(self, char_data: CharacterData) -> None:
+        self._db.execute(
+            "DELETE FROM _sqlcharacterdata WHERE name=?",
+            (char_data.name,),
+        )
 
 
 class _SqlPlayerState(PlayerState):
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+
     def upsert(self, discord_id: int, name: str) -> PlayerData:
-        player = _SqlPlayerData.get_or_none(_SqlPlayerData.discord_id == discord_id)
-        if player is not None:
-            if player.name != name:
-                _SqlPlayerData.update(name=name).where(
-                    _SqlPlayerData.id == player.id
-                ).execute()
-                player.name = name
-            return player
-        return _SqlPlayerData.create(discord_id=discord_id, name=name)  # type: ignore  # peewee Model subclass satisfies PlayerData
+        row = self._db.execute(
+            "INSERT INTO _sqlplayerdata (discord_id, name) VALUES (?, ?)"
+            " ON CONFLICT(discord_id) DO UPDATE SET name=excluded.name"
+            " RETURNING id, discord_id, name",
+            (discord_id, name),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("UPSERT into _sqlplayerdata returned no row")
+        return PlayerData(*row)
 
     def get_from_id(self, player_id: int) -> PlayerData:
-        result = _SqlPlayerData.get_or_none(_SqlPlayerData.id == player_id)
-        if result is None:
+        row = self._db.execute(
+            "SELECT id, discord_id, name FROM _sqlplayerdata WHERE id=?",
+            (player_id,),
+        ).fetchone()
+        if row is None:
             raise KeyError(f"No player with id={player_id}")
-        return result
+        return PlayerData(*row)
 
     def get_from_discord_id(self, discord_id: int) -> PlayerData | None:
-        result = _SqlPlayerData.get_or_none(_SqlPlayerData.discord_id == discord_id)
-        return result
+        row = self._db.execute(
+            "SELECT id, discord_id, name FROM _sqlplayerdata WHERE discord_id=?",
+            (discord_id,),
+        ).fetchone()
+        return PlayerData(*row) if row is not None else None
 
     def get_all(self) -> Sequence[PlayerData]:
-        return tuple(_SqlPlayerData.select())
-
-
-class _SqlCharacterAction(Model):
-    # No foreign-key constraint on character_name: SQLite FK enforcement requires
-    # PRAGMA foreign_keys=ON per connection, which Peewee does not set by default,
-    # and adding it now would risk breaking existing deployments.
-    #
-    # Referential integrity is maintained at the command layer instead:
-    # initbot_chat.commands.character calls remove_all_for_character() before
-    # deleting a character. CharacterState.remove_and_store() does NOT cascade;
-    # any code that removes characters outside the command layer must call
-    # remove_all_for_character() explicitly to avoid leaving orphaned rows.
-    id = AutoField()
-    character_name = CharField()
-    position = IntegerField()  # 0-based; kept contiguous after removes
-    template = CharField()
+        rows = self._db.execute(
+            "SELECT id, discord_id, name FROM _sqlplayerdata"
+        ).fetchall()
+        return [PlayerData(*row) for row in rows]
 
 
 class _SqlCharacterActionState(CharacterActionState):
+    # No foreign-key constraint on character_name: adding PRAGMA foreign_keys=ON
+    # to existing deployments risks breaking them. Referential integrity is
+    # maintained at the command layer instead: initbot_chat.commands.character
+    # calls remove_all_for_character() before deleting a character.
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+
     def get_all_for_character(self, character_name: str) -> Sequence[str]:
-        rows = (
-            _SqlCharacterAction
-            .select()
-            .where(_SqlCharacterAction.character_name == character_name)
-            .order_by(_SqlCharacterAction.position)
-        )
-        return [row.template for row in rows]
+        rows = self._db.execute(
+            "SELECT template FROM _sqlcharacteraction WHERE character_name=? ORDER BY position",
+            (character_name,),
+        ).fetchall()
+        return [row[0] for row in rows]
 
     def add(self, character_name: str, template: str) -> int:
-        next_pos = len(self.get_all_for_character(character_name))
-        _SqlCharacterAction.create(
-            character_name=character_name,
-            position=next_pos,
-            template=template,
-        )
-        return next_pos + 1
+        row = self._db.execute(
+            "INSERT INTO _sqlcharacteraction (character_name, position, template)"
+            " VALUES (?, (SELECT COUNT(*) FROM _sqlcharacteraction WHERE character_name=?), ?)"
+            " RETURNING position + 1",
+            (character_name, character_name, template),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError("INSERT into _sqlcharacteraction returned no row")
+        return row[0]
 
     def update(self, character_name: str, index: int, template: str) -> None:
         actions = self.get_all_for_character(character_name)
         if not 1 <= index <= len(actions):
             raise IndexError(f"Action index {index} out of range (1-{len(actions)})")
-        _SqlCharacterAction.update(template=template).where(
-            (_SqlCharacterAction.character_name == character_name)
-            & (_SqlCharacterAction.position == index - 1)
-        ).execute()
+        self._db.execute(
+            "UPDATE _sqlcharacteraction SET template=? WHERE character_name=? AND position=?",
+            (template, character_name, index - 1),
+        )
 
     def remove(self, character_name: str, index: int) -> None:
         actions = self.get_all_for_character(character_name)
         if not 1 <= index <= len(actions):
             raise IndexError(f"Action index {index} out of range (1-{len(actions)})")
         pos = index - 1
-        _SqlCharacterAction.delete().where(
-            (_SqlCharacterAction.character_name == character_name)
-            & (_SqlCharacterAction.position == pos)
-        ).execute()
-        # Renumber remaining rows to keep positions contiguous
-        _SqlCharacterAction.update(position=_SqlCharacterAction.position - 1).where(
-            (_SqlCharacterAction.character_name == character_name)
-            & (_SqlCharacterAction.position > pos)
-        ).execute()
+        self._db.execute(
+            "DELETE FROM _sqlcharacteraction WHERE character_name=? AND position=?",
+            (character_name, pos),
+        )
+        self._db.execute(
+            "UPDATE _sqlcharacteraction SET position=position-1 WHERE character_name=? AND position>?",
+            (character_name, pos),
+        )
 
     def remove_all_for_character(self, character_name: str) -> None:
-        _SqlCharacterAction.delete().where(
-            _SqlCharacterAction.character_name == character_name
-        ).execute()
+        self._db.execute(
+            "DELETE FROM _sqlcharacteraction WHERE character_name=?",
+            (character_name,),
+        )
 
     def rename_character(self, old_name: str, new_name: str) -> None:
-        _SqlCharacterAction.update(character_name=new_name).where(
-            _SqlCharacterAction.character_name == old_name
-        ).execute()
-
-
-class _SqlWebLoginToken(Model):
-    token = CharField(primary_key=True)
-    discord_id = IntegerField()
-    expires_at = IntegerField()
-    used = BooleanField(default=False)
+        self._db.execute(
+            "UPDATE _sqlcharacteraction SET character_name=? WHERE character_name=?",
+            (new_name, old_name),
+        )
 
 
 class _SqlWebLoginTokenState(WebLoginTokenState):
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+
     def create(self, discord_id: int) -> str:
         token = secrets.token_urlsafe(32)
         now = int(time.time())
-        _SqlWebLoginToken.create(
-            token=token,
-            discord_id=discord_id,
-            expires_at=now + _WEB_LOGIN_TOKEN_TTL,
+        self._db.execute(
+            "INSERT INTO _sqlweblogintoken (token, discord_id, expires_at, used) VALUES (?, ?, ?, 0)",
+            (token, discord_id, now + _WEB_LOGIN_TOKEN_TTL),
         )
         return token
 
     def find_valid(self, token: str) -> int | None:
         now = int(time.time())
-        row = _SqlWebLoginToken.get_or_none(
-            (_SqlWebLoginToken.token == token)
-            & ~_SqlWebLoginToken.used
-            & (_SqlWebLoginToken.expires_at > now)
-        )
-        return row.discord_id if row is not None else None
+        row = self._db.execute(
+            "SELECT discord_id FROM _sqlweblogintoken WHERE token=? AND used=0 AND expires_at>?",
+            (token, now),
+        ).fetchone()
+        return row[0] if row is not None else None
 
     def mark_used(self, token: str) -> None:
-        _SqlWebLoginToken.update(used=True).where(
-            _SqlWebLoginToken.token == token
-        ).execute()
+        self._db.execute(
+            "UPDATE _sqlweblogintoken SET used=1 WHERE token=?",
+            (token,),
+        )
 
     def prune_expired(self) -> None:
         now = int(time.time())
-        _SqlWebLoginToken.delete().where(_SqlWebLoginToken.expires_at <= now).execute()
-
-
-class _SqlSessionSecret(Model):
-    id = IntegerField(primary_key=True)  # single-row table; always id=1
-    secret = CharField()
-    expires_at = IntegerField()
+        self._db.execute(
+            "DELETE FROM _sqlweblogintoken WHERE expires_at<=?",
+            (now,),
+        )
 
 
 class _SqlSessionSecretState(SessionSecretState):
+    def __init__(self, db: sqlite3.Connection) -> None:
+        self._db = db
+
     def _load(self) -> tuple[str, int] | None:
-        row = _SqlSessionSecret.get_or_none(_SqlSessionSecret.id == 1)
-        return (str(row.secret), int(row.expires_at)) if row is not None else None
+        row = self._db.execute(
+            "SELECT secret, expires_at FROM _sqlsessionsecret WHERE id=1"
+        ).fetchone()
+        return (str(row[0]), int(row[1])) if row is not None else None
 
     def _store(self, secret: str, expires_at: int) -> None:
-        _SqlSessionSecret.insert(
-            id=1, secret=secret, expires_at=expires_at
-        ).on_conflict_replace().execute()
+        self._db.execute(
+            "INSERT INTO _sqlsessionsecret (id, secret, expires_at) VALUES (1, ?, ?)"
+            " ON CONFLICT(id) DO UPDATE SET secret=excluded.secret, expires_at=excluded.expires_at",
+            (secret, expires_at),
+        )
 
 
 class SqlState(State):
-    def __init__(
-        self,
-        source: str,
-    ) -> None:
-        self._characters = _SqlCharacterState()
-        self._players = _SqlPlayerState()
-        self._web_login_tokens = _SqlWebLoginTokenState()
-        self._character_actions = _SqlCharacterActionState()
-        self._session_secret = _SqlSessionSecretState()
-
+    def __init__(self, source: str) -> None:
         state_type, state_source = source.split(":", maxsplit=1)
-        if state_type == "sqlite":
-            path = Path(state_source)
-            check_state_directory(source, path.parent)
-            self._db = SqliteDatabase(
-                path,
-                pragmas={"journal_mode": "wal", "synchronous": "normal"},
-            )
-
-        else:
+        if state_type != "sqlite":
             raise ValueError(f"Unsupported state type: {state_type}")
 
-        data_classes = _get_data_classes()
-        self._db.bind(data_classes)
-        self._db.create_tables(data_classes, safe=True)
+        path = Path(state_source)
+        check_state_directory(source, path.parent)
+
+        self._db = sqlite3.connect(
+            path,
+            check_same_thread=False,
+            isolation_level=None,  # autocommit
+        )
+        self._db.execute("PRAGMA journal_mode=WAL;")
+        self._db.execute("PRAGMA synchronous=NORMAL;")
+
+        for statement in _CREATE_TABLES.strip().split(";"):
+            statement = statement.strip()
+            if statement:
+                self._db.execute(statement)
 
         self._migrate(self._db)
 
+        self._characters = _SqlCharacterState(self._db)
+        self._players = _SqlPlayerState(self._db)
+        self._web_login_tokens = _SqlWebLoginTokenState(self._db)
+        self._character_actions = _SqlCharacterActionState(self._db)
+        self._session_secret = _SqlSessionSecretState(self._db)
+
     @staticmethod
-    def _migrate(db: SqliteDatabase) -> None:
-        """Apply schema migrations."""
-        with db.connection_context():
-            # --- _sqlcharacterdata ---
-            cursor = db.execute_sql("PRAGMA table_info(_sqlcharacterdata);")
-            columns = [row[1] for row in cursor.fetchall()]
+    def _migrate(db: sqlite3.Connection) -> None:
+        """Apply schema migrations for databases created by older versions."""
+        cursor = db.execute("PRAGMA table_info(_sqlcharacterdata);")
+        columns = [row[1] for row in cursor.fetchall()]
 
-            obsolete = {
-                "active",
-                "level",
-                "strength",
-                "agility",
-                "stamina",
-                "personality",
-                "intelligence",
-                "luck",
-                "initial_luck",
-                "hit_points",
-                "equipment",
-                "occupation",
-                "exp",
-                "alignment",
-                "initiative_modifier",
-                "initiative_time",
-                "hit_die",
-                "augur",
-                "cls",
-                # legacy names from even older migrations
-                "creation_time",
-                "user",
-            }
-            needs_rebuild = bool(obsolete & set(columns))
+        obsolete = {
+            "active",
+            "level",
+            "strength",
+            "agility",
+            "stamina",
+            "personality",
+            "intelligence",
+            "luck",
+            "initial_luck",
+            "hit_points",
+            "equipment",
+            "occupation",
+            "exp",
+            "alignment",
+            "initiative_modifier",
+            "initiative_time",
+            "hit_die",
+            "augur",
+            "cls",
+            "creation_time",
+            "user",
+        }
+        needs_rebuild = bool(obsolete & set(columns))
 
-            if "initiative_dice" not in columns:
-                db.execute_sql(
-                    "ALTER TABLE _sqlcharacterdata ADD COLUMN initiative_dice TEXT DEFAULT NULL;"
-                )
-            if "last_used" not in columns:
-                db.execute_sql(
-                    "ALTER TABLE _sqlcharacterdata ADD COLUMN last_used INTEGER DEFAULT NULL;"
-                )
-            if "player_id" not in columns:
-                db.execute_sql(
-                    "ALTER TABLE _sqlcharacterdata ADD COLUMN player_id INTEGER DEFAULT NULL;"
-                )
-
-            if needs_rebuild:
-                db.execute_sql("""
-                    CREATE TABLE _sqlcharacterdata_new (
-                        name TEXT NOT NULL PRIMARY KEY,
-                        initiative INTEGER,
-                        initiative_dice TEXT,
-                        last_used INTEGER,
-                        player_id INTEGER
-                    );
-                """)
-                db.execute_sql("""
-                    INSERT INTO _sqlcharacterdata_new
-                        (name, initiative, initiative_dice, last_used, player_id)
-                    SELECT name, initiative, initiative_dice, last_used, player_id
-                    FROM _sqlcharacterdata;
-                """)
-                db.execute_sql("DROP TABLE _sqlcharacterdata;")
-                db.execute_sql(
-                    "ALTER TABLE _sqlcharacterdata_new RENAME TO _sqlcharacterdata;"
-                )
-
-            # Assign a grace-period last_used to rows that have none, so they
-            # are not immediately eligible for pruning after this migration.
-            grace_ts = int(time.time()) - CORE_CFG.prune_threshold_days * 86400 // 2
-            db.execute_sql(
-                "UPDATE _sqlcharacterdata SET last_used = ? WHERE last_used IS NULL;",
-                (grace_ts,),
+        if "initiative_dice" not in columns:
+            db.execute(
+                "ALTER TABLE _sqlcharacterdata ADD COLUMN initiative_dice TEXT DEFAULT NULL;"
             )
+        if "last_used" not in columns:
+            db.execute(
+                "ALTER TABLE _sqlcharacterdata ADD COLUMN last_used INTEGER DEFAULT NULL;"
+            )
+        if "player_id" not in columns:
+            db.execute(
+                "ALTER TABLE _sqlcharacterdata ADD COLUMN player_id INTEGER DEFAULT NULL;"
+            )
+
+        if needs_rebuild:
+            db.execute("""
+                CREATE TABLE _sqlcharacterdata_new (
+                    name TEXT NOT NULL PRIMARY KEY,
+                    player_id INTEGER,
+                    initiative INTEGER,
+                    initiative_dice TEXT,
+                    last_used INTEGER
+                );
+            """)
+            db.execute("""
+                INSERT INTO _sqlcharacterdata_new
+                    (name, player_id, initiative, initiative_dice, last_used)
+                SELECT name, player_id, initiative, initiative_dice, last_used
+                FROM _sqlcharacterdata;
+            """)
+            db.execute("DROP TABLE _sqlcharacterdata;")
+            db.execute("ALTER TABLE _sqlcharacterdata_new RENAME TO _sqlcharacterdata;")
+
+        # Assign a grace-period last_used to rows that have none, so they
+        # are not immediately eligible for pruning after this migration.
+        grace_ts = int(time.time()) - CORE_CFG.prune_threshold_days * 86400 // 2
+        db.execute(
+            "UPDATE _sqlcharacterdata SET last_used=? WHERE last_used IS NULL;",
+            (grace_ts,),
+        )
 
     @property
     def characters(self) -> CharacterState:
@@ -367,11 +398,3 @@ class SqlState(State):
     @property
     def session_secret(self) -> SessionSecretState:
         return self._session_secret
-
-
-def _get_data_classes() -> Sequence[type[Model]]:
-    return tuple(
-        cast(type[Model], i)
-        for i in globals().values()
-        if isclass(i) and issubclass(i, Model) and i is not Model
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dev = [
     "pylint>=3.2.7",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
-    "types-peewee>=4.0.0.20260408",
     "zizmor>=1.23.1",
     "reuse>=6.2.0",
     "mutmut>=3.5.0",
@@ -65,9 +64,6 @@ ignore = [
 ]
 "packages/initbot-core/src/initbot_core/models/roll.py" = [
     "PERF203",  # try/except must be inside the loop to probe each dice class in sequence
-]
-"packages/initbot-core/src/initbot_core/state/sql.py" = [
-    "RUF012",  # peewee Model field assignments are handled by the peewee metaclass, not ClassVar
 ]
 
 [tool.vulture]

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,6 @@ dev = [
     { name = "reuse", specifier = ">=6.2.0" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "ty", specifier = ">=0.0.29" },
-    { name = "types-peewee", specifier = ">=4.0.0.20260408" },
     { name = "vulture", specifier = ">=2.16" },
     { name = "zizmor", specifier = ">=1.23.1" },
 ]
@@ -935,7 +934,6 @@ name = "initbot-core"
 version = "0.1.0"
 source = { editable = "packages/initbot-core" }
 dependencies = [
-    { name = "peewee" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -944,7 +942,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "peewee", specifier = "~=4.0" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings", specifier = "~=2.0" },
     { name = "python-dotenv", specifier = "~=1.2" },
@@ -1597,15 +1594,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "peewee"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/8e/8fe6b93914ed40b9cb5162e45e1be4f8bb8cf7f5a49333aa1a2d383e4870/peewee-4.0.4.tar.gz", hash = "sha256:70e07c14a10bec8d663514bda5854e44ef15d5b03974b41f7218066b6fd3a065", size = 718021, upload-time = "2026-04-02T13:52:25.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/9b/bee274b72adc7c692bf7cb8d6b0cd4071acf2957e82dace45d3f2770470e/peewee-4.0.4-py3-none-any.whl", hash = "sha256:37ccd3f89e523c7b42eed023cd90b48d088753ddff1d74e854a9c6445e7bd797", size = 144487, upload-time = "2026-04-02T13:52:24.099Z" },
 ]
 
 [[package]]
@@ -2606,15 +2594,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331, upload-time = "2026-04-05T15:01:01.32Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644, upload-time = "2026-04-05T15:01:04.432Z" },
     { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165, upload-time = "2026-04-05T15:01:34.665Z" },
-]
-
-[[package]]
-name = "types-peewee"
-version = "4.0.0.20260408"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/e5/79a20fe6cddbe22ceecb06da41bcff0ff1489804f01da2461f9069d39a3f/types_peewee-4.0.0.20260408.tar.gz", hash = "sha256:5ef4d568d463d029473efd0fa0bd0eed4d6e39dfaeb373285e6199fbc6d8a826", size = 22058, upload-time = "2026-04-08T04:33:52.041Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/f4/eba12129d550a4acf5c1430721b15a30b500f7360ff101a3cde1dc222104/types_peewee-4.0.0.20260408-py3-none-any.whl", hash = "sha256:91e9ce92363a119f8b4e249337b3082663b4ad5e0a5e7cedd0a6bf80ded9b9be", size = 19966, upload-time = "2026-04-08T04:33:50.54Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Peewee's metaclass conflict forced `CharacterData` and `PlayerData` to be structural `Protocol`s rather than dataclasses, requiring `cast()` and `# type: ignore` workarounds throughout the storage layer
- `update_and_store()` relied on Peewee internals (`_meta`, `__data__`), fragile and acknowledged with a `pylint: disable` comment
- `_get_data_classes()` discovered Peewee models by scanning `globals()` — brittle by design

Changes:
- Convert `CharacterData` and `PlayerData` from `Protocol`s to `@dataclass`es
- Rewrite `sql.py` using `sqlite3` (stdlib) with explicit parameterized SQL
- Pass db connection explicitly to each `_Sql*State` constructor (eliminates implicit module-global state)
- Replace `_get_data_classes()` auto-discovery with explicit `CREATE TABLE IF NOT EXISTS` statements
- Remove `peewee` dependency from `initbot-core`

The `State` ABC layer, factory, and embedded migration logic are unchanged. No callers in `initbot-chat` or `initbot-web` required modification.

## Test plan

- [x] Start `initbot-chat` against a dev database: set initiative, add/rename/remove a character, add/update/remove an action, generate a `!web` login link
- [x] Start `initbot-web`: verify SSE tracker updates, login flow, initiative edits, character deletion
- [x] Copy a pre-existing `.sqlite` database with legacy columns and confirm startup applies migrations without data loss