### PR TITLE
Use commit SHA (not tag object SHA) for codeql-action pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734  # v3.35.2
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The Scorecard action's publish_results mode verifies that every pinned SHA in the workflow is an actual commit belonging to the referenced repo. Annotated tag SHAs fail this check; dereference to the commit SHA instead.