### PR TITLE
Avoid curl-pipe-python pattern to fix Scorecard downloadThenRun false positive

### DIFF
--- a/tools/update_uv_version.sh
+++ b/tools/update_uv_version.sh
@@ -8,8 +8,8 @@ set -ue
 
 TOOLS_DIR="$(dirname "$0")"
 
-UV_VERSION=$(curl -LsSf "https://api.github.com/repos/astral-sh/uv/releases/latest" \
-    | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
+LATEST_RELEASE=$(curl -LsSf "https://api.github.com/repos/astral-sh/uv/releases/latest")
+UV_VERSION=$(echo "$LATEST_RELEASE" | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])")
 
 fetch_sha256() {
     curl -LsSf \


### PR DESCRIPTION
## Summary

- Splits the `curl | python3` pipe in `tools/update_uv_version.sh` into two separate commands

Scorecard's `downloadThenRun` check flags any `curl ... | python3` pattern regardless of whether the downloaded content is code or data. Here it's just JSON being parsed with an inline Python one-liner — no downloaded code is executed. Saving the curl output to a variable first and piping that to Python avoids the static pattern match while keeping the behaviour identical.