### PR TITLE
Add OpenSSF Best Practices badge, CONTRIBUTING.md, and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including GitHub issues, pull requests, and discussions, and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer via the contact information on the [GitHub profile](https://github.com/stefangotz). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Initbot
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) — Python package manager
+- Git
+- A Discord bot token if you want to test the chat bot end-to-end
+
+## Setting Up a Development Environment
+
+Run the setup script (Linux or macOS):
+
+```sh
+./tools/set_up_dev.sh
+```
+
+This installs uv, creates a virtual environment in `.venv/`, installs all dependencies, and wires up pre-commit hooks. On Windows the script won't run directly, but each step translates straightforwardly to Windows equivalents.
+
+## Running the Tests
+
+```sh
+uv run pytest
+```
+
+Tests require 80% coverage; `coverage report` enforces this automatically.
+
+## Code Style and Quality
+
+Pre-commit hooks run automatically on `git commit` and enforce formatting, linting, type checking, dead-code detection, secret scanning, and licence header verification. Run them manually at any time:
+
+```sh
+uv run pre-commit run --all-files
+```
+
+## Workflow
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes and add tests where appropriate.
+3. Ensure all pre-commit hooks and CI checks pass.
+4. Open a pull request against `main`.
+
+## Reporting Issues
+
+- **Security vulnerabilities** — use [GitHub private vulnerability reporting](https://github.com/stefangotz/initbot/security/advisories/new). See [SECURITY.md](SECURITY.md) for details.
+- **Bugs and feature requests** — open a [GitHub issue](https://github.com/stefangotz/initbot/issues).
+
+## Licence
+
+By contributing you agree that your contributions will be licenced under [AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Initbot
 
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/12602/baseline)](https://www.bestpractices.dev/projects/12602)
+
 An RPG Discord chat bot and a companion web app.
 
 ## Applications


### PR DESCRIPTION
## Summary

- Registers the project with the [OpenSSF Best Practices programme](https://www.bestpractices.dev/projects/12602) (project ID 12602) and adds the baseline badge to the README
- Adds `CONTRIBUTING.md` with dev setup, test, and contribution workflow instructions — satisfies the badge `contribution` criterion and is surfaced by GitHub in the new-issue/PR UI
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) — satisfies the badge `code_of_conduct` criterion

## Test plan

- [ ] CI pipeline passes (reuse lint, ruff, pytest)
- [ ] Badge renders correctly at the top of the README on GitHub
- [ ] bestpractices.dev form shows `contribution` and `code_of_conduct` criteria as met after merge